### PR TITLE
Issue found by Arfath in appdev where contigs were not being filtered in 'meta' mode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### Version 0.0.9
 __Changes__
-- Limit SPAdes and MetaSPAdes memory usage to 100GB and 500GB respectively.
-- 
+- Added min_contig_length parameter for metaSPAdes 
+- Limited MetaSPAdes narrative UI to accept only one reads input
 - 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-### Version x.y.z
+### Version 0.0.9
 __Changes__
-- 
+- Limit SPAdes and MetaSPAdes memory usage to 100GB and 500GB respectively.
 - 
 - 

--- a/kb_SPAdes.spec
+++ b/kb_SPAdes.spec
@@ -31,7 +31,7 @@ module kb_SPAdes {
     dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
                      amplified from a single cell via MDA anything else: Standard
                      DNA sample from multiple cells. Default value is None.
-    min_contig_len - (optional) integer to filter out contigs with len < min_contig_len
+    min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
                      from the SPAdes output. Default value is 0 implying no filter.
 
     */
@@ -40,7 +40,7 @@ module kb_SPAdes {
         string output_contigset_name;
         list<paired_end_lib> read_libraries;
         string dna_source;
-        int min_contig_len;
+        int min_contig_length;
     } SPAdesParams;
 
 

--- a/lib/kb_SPAdes/kb_SPAdesClient.pm
+++ b/lib/kb_SPAdes/kb_SPAdesClient.pm
@@ -134,7 +134,7 @@ SPAdesParams is a reference to a hash where the following keys are defined:
 	output_contigset_name has a value which is a string
 	read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
 	dna_source has a value which is a string
-	min_contig_len has a value which is an int
+	min_contig_length has a value which is an int
 paired_end_lib is a string
 SPAdesOutput is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
@@ -153,7 +153,7 @@ SPAdesParams is a reference to a hash where the following keys are defined:
 	output_contigset_name has a value which is a string
 	read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
 	dna_source has a value which is a string
-	min_contig_len has a value which is an int
+	min_contig_length has a value which is an int
 paired_end_lib is a string
 SPAdesOutput is a reference to a hash where the following keys are defined:
 	report_name has a value which is a string
@@ -377,14 +377,16 @@ a string
 =item Description
 
 Input parameters for running SPAdes.
-string workspace_name - the name of the workspace from which to take
-   input and store output.
-string output_contigset_name - the name of the output contigset
-list<paired_end_lib> read_libraries - Illumina PairedEndLibrary files
-    to assemble.
-string dna_source - the source of the DNA used for sequencing
-    'single_cell': DNA amplified from a single cell via MDA
-    anything else: Standard DNA sample from multiple cells
+
+    workspace_name - the name of the workspace from which to take input
+                     and store output.
+    output_contigset_name - the name of the output contigset list<paired_end_lib>
+                     read_libraries - Illumina PairedEndLibrary files to assemble.
+    dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
+                     amplified from a single cell via MDA anything else: Standard
+                     DNA sample from multiple cells. Default value is None.
+    min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
+                     from the SPAdes output. Default value is 0 implying no filter.
 
 
 =item Definition
@@ -397,7 +399,7 @@ workspace_name has a value which is a string
 output_contigset_name has a value which is a string
 read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
 dna_source has a value which is a string
-min_contig_len has a value which is an int
+min_contig_length has a value which is an int
 
 </pre>
 
@@ -410,7 +412,7 @@ workspace_name has a value which is a string
 output_contigset_name has a value which is a string
 read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
 dna_source has a value which is a string
-min_contig_len has a value which is an int
+min_contig_length has a value which is an int
 
 
 =end text
@@ -428,9 +430,9 @@ min_contig_len has a value which is an int
 =item Description
 
 Output parameters for SPAdes run.
-string report_name - the name of the KBaseReport.Report workspace
-    object.
-string report_ref - the workspace reference of the report.
+
+    report_name - the name of the KBaseReport.Report workspace object.
+    report_ref - the workspace reference of the report.
 
 
 =item Definition

--- a/lib/kb_SPAdes/kb_SPAdesClient.py
+++ b/lib/kb_SPAdes/kb_SPAdesClient.py
@@ -37,24 +37,26 @@ class kb_SPAdes(object):
         """
         Run SPAdes on paired end libraries
         :param params: instance of type "SPAdesParams" (Input parameters for
-           running SPAdes. string workspace_name - the name of the workspace
-           from which to take input and store output. string
-           output_contigset_name - the name of the output contigset
-           list<paired_end_lib> read_libraries - Illumina PairedEndLibrary
-           files to assemble. string dna_source - the source of the DNA used
-           for sequencing 'single_cell': DNA amplified from a single cell via
-           MDA anything else: Standard DNA sample from multiple cells) ->
-           structure: parameter "workspace_name" of String, parameter
-           "output_contigset_name" of String, parameter "read_libraries" of
-           list of type "paired_end_lib" (The workspace object name of a
-           PairedEndLibrary file, whether of the KBaseAssembly or KBaseFile
-           type.), parameter "dna_source" of String, parameter
-           "min_contig_len" of Long
+           running SPAdes. workspace_name - the name of the workspace from
+           which to take input and store output. output_contigset_name - the
+           name of the output contigset list<paired_end_lib> read_libraries -
+           Illumina PairedEndLibrary files to assemble. dna_source -
+           (optional) the source of the DNA used for sequencing
+           'single_cell': DNA amplified from a single cell via MDA anything
+           else: Standard DNA sample from multiple cells. Default value is
+           None. min_contig_length - (optional) integer to filter out contigs
+           with length < min_contig_length from the SPAdes output. Default
+           value is 0 implying no filter.) -> structure: parameter
+           "workspace_name" of String, parameter "output_contigset_name" of
+           String, parameter "read_libraries" of list of type
+           "paired_end_lib" (The workspace object name of a PairedEndLibrary
+           file, whether of the KBaseAssembly or KBaseFile type.), parameter
+           "dna_source" of String, parameter "min_contig_length" of Long
         :returns: instance of type "SPAdesOutput" (Output parameters for
-           SPAdes run. string report_name - the name of the
-           KBaseReport.Report workspace object. string report_ref - the
-           workspace reference of the report.) -> structure: parameter
-           "report_name" of String, parameter "report_ref" of String
+           SPAdes run. report_name - the name of the KBaseReport.Report
+           workspace object. report_ref - the workspace reference of the
+           report.) -> structure: parameter "report_name" of String,
+           parameter "report_ref" of String
         """
         return self._client.call_method(
             'kb_SPAdes.run_SPAdes',

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -58,7 +58,7 @@ A coverage cutoff is not specified.
     ######################################### noqa
     VERSION = "0.0.9"
     GIT_URL = "https://github.com/kbaseapps/kb_SPAdes.git"
-    GIT_COMMIT_HASH = "b0c01d8e21a27afc36f3492eb738ef07e634f99c"
+    GIT_COMMIT_HASH = "e3b02ff7e155b20a51c390fcbc306f5a043467d8"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -56,9 +56,9 @@ A coverage cutoff is not specified.
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.8"
-    GIT_URL = "https://github.com/dcchivian/kb_SPAdes"
-    GIT_COMMIT_HASH = "4c784fdebd820ad751423b61772539749aeb79cc"
+    VERSION = "0.0.9"
+    GIT_URL = "https://github.com/kbaseapps/kb_SPAdes.git"
+    GIT_COMMIT_HASH = "b0c01d8e21a27afc36f3492eb738ef07e634f99c"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
@@ -502,8 +502,27 @@ A coverage cutoff is not specified.
     def run_SPAdes(self, ctx, params):
         """
         Run SPAdes on paired end libraries
-        :param params: (See kb_SPAdes.spec for details)
-        :returns: (See kb_SPAdes.spec for details)
+        :param params: instance of type "SPAdesParams" (Input parameters for
+           running SPAdes. workspace_name - the name of the workspace from
+           which to take input and store output. output_contigset_name - the
+           name of the output contigset list<paired_end_lib> read_libraries -
+           Illumina PairedEndLibrary files to assemble. dna_source -
+           (optional) the source of the DNA used for sequencing
+           'single_cell': DNA amplified from a single cell via MDA anything
+           else: Standard DNA sample from multiple cells. Default value is
+           None. min_contig_length - (optional) integer to filter out contigs
+           with length < min_contig_length from the SPAdes output. Default
+           value is 0 implying no filter.) -> structure: parameter
+           "workspace_name" of String, parameter "output_contigset_name" of
+           String, parameter "read_libraries" of list of type
+           "paired_end_lib" (The workspace object name of a PairedEndLibrary
+           file, whether of the KBaseAssembly or KBaseFile type.), parameter
+           "dna_source" of String, parameter "min_contig_length" of Long
+        :returns: instance of type "SPAdesOutput" (Output parameters for
+           SPAdes run. report_name - the name of the KBaseReport.Report
+           workspace object. report_ref - the workspace reference of the
+           report.) -> structure: parameter "report_name" of String,
+           parameter "report_ref" of String
         """
         # ctx is the context object
         # return variables are: output

--- a/lib/src/us/kbase/kbspades/SPAdesOutput.java
+++ b/lib/src/us/kbase/kbspades/SPAdesOutput.java
@@ -15,9 +15,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: SPAdesOutput</p>
  * <pre>
  * Output parameters for SPAdes run.
- * string report_name - the name of the KBaseReport.Report workspace
- *     object.
- * string report_ref - the workspace reference of the report.
+ *     report_name - the name of the KBaseReport.Report workspace object.
+ *     report_ref - the workspace reference of the report.
  * </pre>
  * 
  */

--- a/lib/src/us/kbase/kbspades/SPAdesParams.java
+++ b/lib/src/us/kbase/kbspades/SPAdesParams.java
@@ -16,14 +16,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: SPAdesParams</p>
  * <pre>
  * Input parameters for running SPAdes.
- * string workspace_name - the name of the workspace from which to take
- *    input and store output.
- * string output_contigset_name - the name of the output contigset
- * list<paired_end_lib> read_libraries - Illumina PairedEndLibrary files
- *     to assemble.
- * string dna_source - the source of the DNA used for sequencing
- *     'single_cell': DNA amplified from a single cell via MDA
- *     anything else: Standard DNA sample from multiple cells
+ *     workspace_name - the name of the workspace from which to take input
+ *                      and store output.
+ *     output_contigset_name - the name of the output contigset list<paired_end_lib>
+ *                      read_libraries - Illumina PairedEndLibrary files to assemble.
+ *     dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
+ *                      amplified from a single cell via MDA anything else: Standard
+ *                      DNA sample from multiple cells. Default value is None.
+ *     min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
+ *                      from the SPAdes output. Default value is 0 implying no filter.
  * </pre>
  * 
  */
@@ -34,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "output_contigset_name",
     "read_libraries",
     "dna_source",
-    "min_contig_len"
+    "min_contig_length"
 })
 public class SPAdesParams {
 
@@ -46,8 +47,8 @@ public class SPAdesParams {
     private List<String> readLibraries;
     @JsonProperty("dna_source")
     private java.lang.String dnaSource;
-    @JsonProperty("min_contig_len")
-    private Long minContigLen;
+    @JsonProperty("min_contig_length")
+    private Long minContigLength;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("workspace_name")
@@ -110,18 +111,18 @@ public class SPAdesParams {
         return this;
     }
 
-    @JsonProperty("min_contig_len")
-    public Long getMinContigLen() {
-        return minContigLen;
+    @JsonProperty("min_contig_length")
+    public Long getMinContigLength() {
+        return minContigLength;
     }
 
-    @JsonProperty("min_contig_len")
-    public void setMinContigLen(Long minContigLen) {
-        this.minContigLen = minContigLen;
+    @JsonProperty("min_contig_length")
+    public void setMinContigLength(Long minContigLength) {
+        this.minContigLength = minContigLength;
     }
 
-    public SPAdesParams withMinContigLen(Long minContigLen) {
-        this.minContigLen = minContigLen;
+    public SPAdesParams withMinContigLength(Long minContigLength) {
+        this.minContigLength = minContigLength;
         return this;
     }
 
@@ -137,7 +138,7 @@ public class SPAdesParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((("SPAdesParams"+" [workspaceName=")+ workspaceName)+", outputContigsetName=")+ outputContigsetName)+", readLibraries=")+ readLibraries)+", dnaSource=")+ dnaSource)+", minContigLen=")+ minContigLen)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((("SPAdesParams"+" [workspaceName=")+ workspaceName)+", outputContigsetName=")+ outputContigsetName)+", readLibraries=")+ readLibraries)+", dnaSource=")+ dnaSource)+", minContigLength=")+ minContigLength)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/ui/narrative/methods/run_SPAdes/display.yaml
+++ b/ui/narrative/methods/run_SPAdes/display.yaml
@@ -43,7 +43,7 @@ parameters :
             Output ContigSet
         short-hint : |
             The name under which the resulting ContigSet will be saved in the Narrative
-    min_contig_len :
+    min_contig_length :
         ui-name : |
             Minimum Contig Length
         short-hint : |

--- a/ui/narrative/methods/run_SPAdes/spec.json
+++ b/ui/narrative/methods/run_SPAdes/spec.json
@@ -58,7 +58,7 @@
             }
         },
         {
-            "id": "min_contig_len",
+            "id": "min_contig_length",
             "optional": false,
             "advanced": true,
             "allow_multiple": false,
@@ -93,8 +93,8 @@
                     "target_property": "dna_source"
                 },
                 {
-                    "input_parameter": "min_contig_len",
-                    "target_property": "min_contig_len"
+                    "input_parameter": "min_contig_length",
+                    "target_property": "min_contig_length"
                 }
             ],
             "output_mapping": [

--- a/ui/narrative/methods/run_metaSPAdes/display.yaml
+++ b/ui/narrative/methods/run_metaSPAdes/display.yaml
@@ -37,7 +37,7 @@ parameters :
             Output ContigSet
         short-hint : |
             The name under which the resulting ContigSet will be saved in the Narrative
-    min_contig_len :
+    min_contig_length :
         ui-name : |
             Minimum Contig Length
         short-hint : |

--- a/ui/narrative/methods/run_metaSPAdes/spec.json
+++ b/ui/narrative/methods/run_metaSPAdes/spec.json
@@ -34,7 +34,7 @@
             }
         },
         {
-            "id": "min_contig_len",
+            "id": "min_contig_length",
             "optional": false,
             "advanced": true,
             "allow_multiple": false,
@@ -66,8 +66,8 @@
                     "target_property": "output_contigset_name"
                 },
                 {
-                    "input_parameter": "min_contig_len",
-                    "target_property": "min_contig_len"
+                    "input_parameter": "min_contig_length",
+                    "target_property": "min_contig_length"
                 },
                 {
                     "constant_value": "metagenomic",


### PR DESCRIPTION
This issue is related to the wrongly named variable (min_contig_len instead of min_contig_length) in kb_SPAdes. The module spec and ui specs needed to be updated and client code regenerated. The variable name is now consistent with the variable name in AssemblyUtils.  

This issue relates to TASK-634