### PR TITLE
update min_contig_length default for MG assembly.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,3 +6,9 @@ __Changes__
 - Removed requirement for 'single_genome' flag not set for metagenomic assembly
 - Added travis CI
 
+
+
+### Version 1.0.0
+__Changes__
+- updated metaSPAdes() min_contig_length parameter to required and changed default values to min:300bp default: 2Kbp
+

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.13
+    1.0.0
 
 owners:
     [gaprice, jkbaumohl, rsutormin, dylan, arfath, sychan]

--- a/test/kb_SPAdes_server_test.py
+++ b/test/kb_SPAdes_server_test.py
@@ -699,10 +699,10 @@ class gaprice_SPAdesTest(unittest.TestCase):
              'fasta_md5': '8da1994279e071c9dd2b2cef57c7f092'
              }, min_contig_length=63000, dna_source='metagenomic')
 
-    def test_invalid_min_contig_len(self):
+    def test_invalid_min_contig_length(self):
 
         self.run_error(
-            ['foo'], 'min_contig_len must be of type int', wsname='fake', min_contig_len='not an int!')
+            ['foo'], 'min_contig_length must be of type int', wsname='fake', min_contig_length='not an int!')
     
     def test_no_workspace_param(self):
 

--- a/ui/narrative/methods/run_metaSPAdes/spec.json
+++ b/ui/narrative/methods/run_metaSPAdes/spec.json
@@ -1,5 +1,5 @@
 {
-    "ver": "0.0.1",
+    "ver": "1.0.0",
     "authors": [
         "gaprice", "dylan"
     ],
@@ -36,13 +36,13 @@
         {
             "id": "min_contig_length",
             "optional": false,
-            "advanced": true,
+            "advanced": false,
             "allow_multiple": false,
-            "default_values": [ "500" ],
+            "default_values": [ "2000" ],
             "field_type": "text",
             "text_options": {
                 "validate_as" : "int",
-		"min_int" : 200
+		"min_int" : 300
             }
         }
     ],


### PR DESCRIPTION
Unit tests take 4.5 hours.  41 of 43 unit tests passed, with only failures in unit tests meant to exercise logic external to App itself.  I consider this acceptance, and am not going to re-run it all just for these two superfluous tests.