### PR TITLE
SCT-656 Addition of kmer sizes and skip error correction parameters.

### DIFF
--- a/kb_SPAdes.spec
+++ b/kb_SPAdes.spec
@@ -33,8 +33,13 @@ module kb_SPAdes {
                      DNA sample from multiple cells. Default value is None.
     min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
                      from the SPAdes output. Default value is 0 implying no filter.
-
+    kmer_sizes - (optional) K-mer sizes, Default values: 33, 55, 77, 99, 127
+                     (all values must be odd, less than 128 and listed in ascending order)
+                     In the absence of these values, K values are automatically selected.
+    skip_error_correction - (optional) Assembly only (No error correction).
+                     By default this is disabled.
     */
+
     typedef structure {
         string workspace_name;
         string output_contigset_name;

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -508,9 +508,6 @@ A coverage cutoff is not specified.
                 raise ValueError('min_contig_length must be of type int')
         if self.PARAM_IN_KMER_SIZES in params and params[self.PARAM_IN_KMER_SIZES] is not None:
             print("KMER_SIZES: " + ",".join(str(num) for num in params[self.PARAM_IN_KMER_SIZES]))
-            if len(params[self.PARAM_IN_KMER_SIZES]) < 3:
-                raise ValueError('Insufficient number of k-mer sizes: Expected atleast 3 values: ' +
-                                 ",".join(str(num) for num in params[self.PARAM_IN_KMER_SIZES]))
         if self.PARAM_IN_SKIP_ERR_CORRECT in params and params[self.PARAM_IN_SKIP_ERR_CORRECT] is not None:
             print("SKIP ERR CORRECTION: " + str(params[self.PARAM_IN_SKIP_ERR_CORRECT]))
 

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import os
 import re
 import uuid
-from pprint import pformat  # , pprint
+from pprint import pformat, pprint
 from biokbase.workspace.client import Workspace as workspaceService  # @UnresolvedImport @IgnorePep8
 import requests
 import json
@@ -199,7 +199,7 @@ A coverage cutoff is not specified.
             yaml.safe_dump(yml, yml_file)
         return yml_path, iontorrent_present
 
-    def exec_spades(self, dna_source, reads_data, phred_type):
+    def exec_spades(self, dna_source, reads_data, phred_type, kmer_sizes, skip_error_correction):
         mem = (psutil.virtual_memory().available / self.GB -
                self.MEMORY_OFFSET_GB)
         if mem < self.MIN_MEMORY_GB:
@@ -256,6 +256,12 @@ A coverage cutoff is not specified.
         else:
             cmd += ['--careful']
         cmd += ['--phred-offset', phred_type]
+
+        if kmer_sizes is not None:
+            cmd += ['-k ' + kmer_sizes]
+        if skip_error_correction == 1:
+            cmd += ['--only-assembler']
+
 #        print("LENGTH OF READSDATA IN EXEC: " + str(len(reads_data)))
 #        print("READS DATA: " + str(reads_data))
 #        print("SPADES YAML: " + str(self.generate_spades_yaml(reads_data)))
@@ -279,7 +285,6 @@ A coverage cutoff is not specified.
         if p.returncode != 0:
             raise ValueError('Error running SPAdes, return code: ' +
                              str(retcode) + '\n')
-
         return outdir
 
     # adapted from
@@ -501,11 +506,13 @@ A coverage cutoff is not specified.
         if self.PARAM_IN_MIN_CONTIG_LENGTH in params:
             if not isinstance(params[self.PARAM_IN_MIN_CONTIG_LENGTH], int):
                 raise ValueError('min_contig_length must be of type int')
-        if self.PARAM_IN_KMER_SIZES in params:
-            for size in params[self.PARAM_IN_KMER_SIZES]:
-                print("KMER SIZE: " + str(size))
-        if self.PARAM_IN_SKIP_ERR_CORRECT in params:
-            print("SKIP ERR CORRECTION: " + str(params(self.PARAM_IN_SKIP_ERR_CORRECT)))
+        if self.PARAM_IN_KMER_SIZES in params and params[self.PARAM_IN_KMER_SIZES] is not None:
+            print("KMER_SIZES: " + ",".join(str(num) for num in params[self.PARAM_IN_KMER_SIZES]))
+            if len(params[self.PARAM_IN_KMER_SIZES]) < 3:
+                raise ValueError('Insufficient number of k-mer sizes: Expected atleast 3 values: ' +
+                                 ",".join(str(num) for num in params[self.PARAM_IN_KMER_SIZES]))
+        if self.PARAM_IN_SKIP_ERR_CORRECT in params and params[self.PARAM_IN_SKIP_ERR_CORRECT] is not None:
+            print("SKIP ERR CORRECTION: " + str(params[self.PARAM_IN_SKIP_ERR_CORRECT]))
 
     #END_CLASS_HEADER
 
@@ -625,8 +632,23 @@ A coverage cutoff is not specified.
                                    'seq_tech': seq_tech})
             else:
                 raise ValueError('Something is very wrong with read lib' + reads_name)
+
+        kmer_sizes = None
+        if self.PARAM_IN_KMER_SIZES in params and params[self.PARAM_IN_KMER_SIZES] is not None:
+            if (len(params[self.PARAM_IN_KMER_SIZES])) > 0:
+                kmer_sizes = ",".join(str(num) for num in params[self.PARAM_IN_KMER_SIZES])
+
+        skip_error_correction = 0
+        if self.PARAM_IN_SKIP_ERR_CORRECT in params and params[self.PARAM_IN_SKIP_ERR_CORRECT] is not None:
+            if params[self.PARAM_IN_SKIP_ERR_CORRECT] == 1:
+                skip_error_correction = 1
+
         spades_out = self.exec_spades(params[self.PARAM_IN_DNA_SOURCE],
-                                      reads_data, phred_type)
+                                      reads_data,
+                                      phred_type,
+                                      kmer_sizes,
+                                      skip_error_correction)
+
         self.log('SPAdes output dir: ' + spades_out)
 
         # parse the output and save back to KBase
@@ -635,8 +657,6 @@ A coverage cutoff is not specified.
         self.log('Uploading FASTA file to Assembly')
 
         assemblyUtil = AssemblyUtil(self.callbackURL, token=ctx['token'], service_ver='release')
-
-
 
         if params.get('min_contig_length', 0) > 0:
             assemblyUtil.save_assembly_from_fasta(

--- a/test/kb_SPAdes_server_test.py
+++ b/test/kb_SPAdes_server_test.py
@@ -492,21 +492,15 @@ class gaprice_SPAdesTest(unittest.TestCase):
     def test_meta_kmer_sizes(self):
 
         self.run_success(
-            ['frbasic'], 'frbasic_out',
+            ['frbasic'], 'frbasic_meta_out',
             contig_count=2, dna_source='metagenomic',
             kmer_sizes=[33, 55, 77, 99, 127])
-
-    def test_invalid_kmer_sizes(self):
-
-        self.run_error(
-            ['frbasic'], 'Insufficient number of k-mer sizes: Expected atleast 3 values: 33',
-            kmer_sizes=[33])
 
     def test_invalid_min_contig_length(self):
 
         self.run_error(
             ['frbasic'], 'min_contig_length must be of type int', min_contig_length='not an int!')
-    
+
     def test_no_workspace_param(self):
 
         self.run_error(

--- a/test/kb_SPAdes_server_test.py
+++ b/test/kb_SPAdes_server_test.py
@@ -472,7 +472,6 @@ class gaprice_SPAdesTest(unittest.TestCase):
             ['single_end'], 'single_out',
             dna_source='None')
 
-
     def test_multiple_bad(self):
         # Testing where input reads have different phred types (33 and 64)
         self.run_error(['intbasic64', 'frbasic'],
@@ -490,6 +489,18 @@ class gaprice_SPAdesTest(unittest.TestCase):
             ['frbasic'], 'single_cell_out',
             dna_source='single_cell')
 
+    def test_meta_kmer_sizes(self):
+
+        self.run_success(
+            ['frbasic'], 'frbasic_out',
+            contig_count=2, dna_source='metagenomic',
+            kmer_sizes=[33, 55, 77, 99, 127])
+
+    def test_invalid_kmer_sizes(self):
+
+        self.run_error(
+            ['frbasic'], 'Insufficient number of k-mer sizes: Expected atleast 3 values: 33',
+            kmer_sizes=[33])
 
     def test_invalid_min_contig_length(self):
 
@@ -682,7 +693,8 @@ class gaprice_SPAdesTest(unittest.TestCase):
 # # don't check ver or commit since they can change from run to run
 
     def run_error(self, readnames, error, wsname=('fake'), output_name='out',
-                  dna_source=None, min_contig_length=0, exception=ValueError):
+                  dna_source=None, min_contig_length=0, exception=ValueError,
+                  kmer_sizes=None, skip_error_correction=0):
 
         test_name = inspect.stack()[1][3]
         print('\n***** starting expected fail test: ' + test_name + ' *****')
@@ -708,18 +720,20 @@ class gaprice_SPAdesTest(unittest.TestCase):
             params['dna_source'] = dna_source
 
         params['min_contig_length'] = min_contig_length
+        params['kmer_sizes'] = kmer_sizes
+        params['skip_error_correction'] = skip_error_correction
 
         with self.assertRaises(exception) as context:
             self.getImpl().run_SPAdes(self.ctx, params)
         self.assertEqual(error, str(context.exception.message))
 
     def run_success(self, readnames, output_name, expected=None, contig_count=None,
-                    min_contig_length=0, dna_source=None):
+                    min_contig_length=0, dna_source=None,
+                    kmer_sizes=None, skip_error_correction=0):
 
         test_name = inspect.stack()[1][3]
         print('\n**** starting expected success test: ' + test_name + ' *****')
         print('   libs: ' + str(readnames))
-
 
         print("READNAMES: " + str(readnames))
         print("STAGED: " + str(self.staged))
@@ -731,7 +745,9 @@ class gaprice_SPAdesTest(unittest.TestCase):
         params = {'workspace_name': self.getWsName(),
                   'read_libraries': libs,
                   'output_contigset_name': output_name,
-                  'min_contig_length': min_contig_length
+                  'min_contig_length': min_contig_length,
+                  'kmer_sizes': kmer_sizes,
+                  'skip_error_correction': skip_error_correction
                   }
 
         if not (dna_source is None):
@@ -817,7 +833,7 @@ class gaprice_SPAdesTest(unittest.TestCase):
                   # They changed because the SPAdes version changed and
                   # Need to see them to update the tests accordingly.
                   # If code gets here this test is designed to always fail, but show results.
-                  self.assertEqual(str(assembly['data']['contigs']),"BLAH")
+                  self.assertEqual(str(assembly['data']['contigs']), "BLAH")
 
 
     def run_non_deterministic_success(self, readnames, output_name,

--- a/ui/narrative/methods/run_SPAdes/display.yaml
+++ b/ui/narrative/methods/run_SPAdes/display.yaml
@@ -48,6 +48,17 @@ parameters :
             Minimum Contig Length
         short-hint : |
             The shortest contig to accept in the resulting assembly object
+    kmer_sizes :
+        ui-name : |
+            K-mer Sizes
+        short-hint : |
+            K-mer sizes (all values must be odd, less than 128 and listed in ascending order)
+            In the absence of these values, K values are automatically selected.
+    skip_error_correction :
+        ui-name : |
+            Assembly only (No Error Correction)
+        short-hint : |
+            Assembly only (No Error Correction)
 description : |
     <p>
     This is a KBase wrapper for the 
@@ -71,7 +82,7 @@ description : |
         <li> Metagenome assembly can only be run on a paired end library.</li>
         <li> Illumina and IonTorrent reads can not be mixed in the same assembly.</li>
         <li> PacBIO CLR needs to be run with at least one accompanying Illumina or IonTorrent library.</li>
-        <li> The k-mer parameter is autodetected by SPAdes.</li>
+        <li> The k-mer parameter is autodetected by SPAdes, if the values are not specified in input.</li>
         <li> The PHRED parameter is autodetected by EAUtils.</li>
     </ul>
     If you need support for command line options not exposed in the wrapper

--- a/ui/narrative/methods/run_SPAdes/spec.json
+++ b/ui/narrative/methods/run_SPAdes/spec.json
@@ -66,7 +66,30 @@
             "field_type": "text",
             "text_options": {
                 "validate_as" : "int",
-		"min_int" : 200
+		        "min_int" : 200
+            }
+        },
+        {
+            "id": "kmer_sizes",
+            "optional": true,
+            "advanced": true,
+            "allow_multiple": true,
+            "default_values": [ ],
+            "field_type": "text",
+            "text_options": {
+                "validate_as" : "int"
+            }
+        },
+        {
+            "id": "skip_error_correction",
+            "optional": true,
+            "advanced": true,
+            "allow_multiple": false,
+            "default_values": [ "0" ],
+            "field_type": "checkbox",
+            "checkbox_options": {
+                "checked_value": "1",
+                "unchecked_value": "0"
             }
         }
     ],
@@ -95,6 +118,14 @@
                 {
                     "input_parameter": "min_contig_length",
                     "target_property": "min_contig_length"
+                },
+                {
+                    "input_parameter": "kmer_sizes",
+                    "target_property": "kmer_sizes"
+                },
+                {
+                    "input_parameter": "skip_error_correction",
+                    "target_property": "skip_error_correction"
                 }
             ],
             "output_mapping": [

--- a/ui/narrative/methods/run_metaSPAdes/display.yaml
+++ b/ui/narrative/methods/run_metaSPAdes/display.yaml
@@ -44,9 +44,10 @@ parameters :
             The shortest contig to accept in the resulting assembly object
     kmer_sizes :
         ui-name : |
-            k-mer Sizes
+            K-mer Sizes
         short-hint : |
-            k-mer sizes (all values must be odd, less than 128 and listed in ascending order)
+            K-mer sizes, Default values: 33, 55, 77, 99, 127 (all values must be odd, less than 128 and
+            listed in ascending order). In the absence of these values, K values are automatically selected.
     skip_error_correction :
         ui-name : |
             Assembly only (No Error Correction)
@@ -75,7 +76,7 @@ description : |
         <li> Metagenome assembly can only be run on a paired end library.</li>
         <li> Illumina and IonTorrent reads can not be mixed in the same assembly.</li>
         <li> PacBIO CLR needs to be run with at least one accompanying Illumina or IonTorrent library.</li>
-        <li> The k-mer parameter is autodetected by SPAdes.</li>
+        <li> The k-mer parameter is autodetected by SPAdes, if the values are not specified in input.</li>
         <li> The PHRED parameter is autodetected by EAUtils.</li>
     </ul>
     If you need support for command line options not exposed in the wrapper

--- a/ui/narrative/methods/run_metaSPAdes/spec.json
+++ b/ui/narrative/methods/run_metaSPAdes/spec.json
@@ -18,7 +18,7 @@
             "default_values": [ "" ],
             "field_type": "text",
             "text_options": {
-                "valid_ws_types": ["KBaseFile.PairedEndLibrary", "KBaseAssembly.PairedEndLibrary", "KBaseFile.SingleEndLibrary", "KBaseAssembly.SingleEndLibrary"]
+                "valid_ws_types": ["KBaseFile.PairedEndLibrary", "KBaseAssembly.PairedEndLibrary"]
             }
         },
         {


### PR DESCRIPTION
- kmer sizes parameter given as -k comma-separated-integers. The documentation does not specify the minimum number of integer values for kmer sizes. Ran Spades with a minimum of 1 int value for kmer sizes. It did not complain. So the allowed number of kmer sizes are from 1. In the absence of kmer sizes, the values are not given as command line arguments, and hence SPAdes will auto select.

- skip error correction uses the command line argument, --only-assembler.