### PR TITLE
generate stats on scaffolds.fasta instead of contigs.fasta

### DIFF
--- a/kb_SPAdes.spec
+++ b/kb_SPAdes.spec
@@ -48,8 +48,6 @@ module kb_SPAdes {
         bool skip_error_correction;
     } SPAdesParams;
 
-
-
     /* An X/Y/Z style KBase object reference
     */
     typedef string obj_ref;
@@ -78,7 +76,7 @@ module kb_SPAdes {
     } LongReadsParams;
 
 
-    /*------To run SPAdes 3.13.0 you need at least one library of the following types:------
+    /*------To run HybridSPAdes 3.13.0 you need at least one library of the following types:------
     1) Illumina paired-end/high-quality mate-pairs/unpaired reads
     2) IonTorrent paired-end/high-quality mate-pairs/unpaired reads
     3) PacBio CCS reads
@@ -97,10 +95,12 @@ module kb_SPAdes {
     kmer_sizes - (optional) K-mer sizes, Default values: 21, 33, 55, 77, 99, 127
                      (all values must be odd, less than 128 and listed in ascending order)
                      In the absence of these values, K values are automatically selected.
-    
+    min_contig_length - integer to filter out contigs with length < min_contig_length
+                     from the HybridSPAdes output. Default value is 0 implying no filter.    
     @optional dna_source
     @optional pipeline_options
     @optional kmer_sizes
+    @optional min_contig_length
     */
 
     typedef structure {
@@ -112,9 +112,9 @@ module kb_SPAdes {
         string dna_source;
         list<string> pipeline_options;
         list<int> kmer_sizes;
+        int min_contig_length;
         bool create_report;
     } HybridSPAdesParams;
-
 
     /* Output parameters for SPAdes run.
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.2.0
+    1.2.1
 
 owners:
     [gaprice, jkbaumohl, rsutormin, dylan, arfath, sychan, psdehal, umaganapathyswork, bsadkhin, qzhang]

--- a/lib/kb_SPAdes/kb_SPAdesClient.pm
+++ b/lib/kb_SPAdes/kb_SPAdesClient.pm
@@ -245,6 +245,7 @@ HybridSPAdesParams is a reference to a hash where the following keys are defined
 	dna_source has a value which is a string
 	pipeline_options has a value which is a reference to a list where each element is a string
 	kmer_sizes has a value which is a reference to a list where each element is an int
+	min_contig_length has a value which is an int
 	create_report has a value which is a kb_SPAdes.bool
 ReadsParams is a reference to a hash where the following keys are defined:
 	lib_ref has a value which is a kb_SPAdes.obj_ref
@@ -275,6 +276,7 @@ HybridSPAdesParams is a reference to a hash where the following keys are defined
 	dna_source has a value which is a string
 	pipeline_options has a value which is a reference to a list where each element is a string
 	kmer_sizes has a value which is a reference to a list where each element is an int
+	min_contig_length has a value which is an int
 	create_report has a value which is a kb_SPAdes.bool
 ReadsParams is a reference to a hash where the following keys are defined:
 	lib_ref has a value which is a kb_SPAdes.obj_ref
@@ -786,7 +788,7 @@ long_reads_type has a value which is a string
 
 =item Description
 
-------To run SPAdes 3.13.0 you need at least one library of the following types:------
+------To run HybridSPAdes 3.13.0 you need at least one library of the following types:------
 1) Illumina paired-end/high-quality mate-pairs/unpaired reads
 2) IonTorrent paired-end/high-quality mate-pairs/unpaired reads
 3) PacBio CCS reads
@@ -805,10 +807,12 @@ pipeline_options - a list of string specifying how the SPAdes pipeline should be
 kmer_sizes - (optional) K-mer sizes, Default values: 21, 33, 55, 77, 99, 127
                  (all values must be odd, less than 128 and listed in ascending order)
                  In the absence of these values, K values are automatically selected.
-
+min_contig_length - integer to filter out contigs with length < min_contig_length
+                 from the HybridSPAdes output. Default value is 0 implying no filter.    
 @optional dna_source
 @optional pipeline_options
 @optional kmer_sizes
+@optional min_contig_length
 
 
 =item Definition
@@ -824,6 +828,7 @@ long_reads_libraries has a value which is a reference to a list where each eleme
 dna_source has a value which is a string
 pipeline_options has a value which is a reference to a list where each element is a string
 kmer_sizes has a value which is a reference to a list where each element is an int
+min_contig_length has a value which is an int
 create_report has a value which is a kb_SPAdes.bool
 
 </pre>
@@ -840,6 +845,7 @@ long_reads_libraries has a value which is a reference to a list where each eleme
 dna_source has a value which is a string
 pipeline_options has a value which is a reference to a list where each element is a string
 kmer_sizes has a value which is a reference to a list where each element is an int
+min_contig_length has a value which is an int
 create_report has a value which is a kb_SPAdes.bool
 
 

--- a/lib/kb_SPAdes/kb_SPAdesClient.py
+++ b/lib/kb_SPAdes/kb_SPAdesClient.py
@@ -74,7 +74,7 @@ class kb_SPAdes(object):
         """
         Run HybridSPAdes on paired end libraries with PacBio CLR and Oxford Nanopore reads
         :param params: instance of type "HybridSPAdesParams" (------To run
-           SPAdes 3.13.0 you need at least one library of the following
+           HybridSPAdes 3.13.0 you need at least one library of the following
            types:------ 1) Illumina paired-end/high-quality
            mate-pairs/unpaired reads 2) IonTorrent paired-end/high-quality
            mate-pairs/unpaired reads 3) PacBio CCS reads Version 3.13.0 of
@@ -94,30 +94,33 @@ class kb_SPAdes(object):
            (optional) K-mer sizes, Default values: 21, 33, 55, 77, 99, 127
            (all values must be odd, less than 128 and listed in ascending
            order) In the absence of these values, K values are automatically
-           selected. @optional dna_source @optional pipeline_options
-           @optional kmer_sizes) -> structure: parameter "workspace_name" of
-           String, parameter "output_contigset_name" of String, parameter
-           "reads_libraries" of list of type "ReadsParams" (parameter
-           groups--define attributes for specifying inputs with YAML data set
-           file (advanced) The following attributes are available: -
-           orientation ("fr", "rf", "ff") - type ("paired-end", "mate-pairs",
-           "hq-mate-pairs", "single", "pacbio", "nanopore", "sanger",
-           "trusted-contigs", "untrusted-contigs") - interlaced reads
-           (comma-separated list of files with interlaced reads) - left reads
-           (comma-separated list of files with left reads) - right reads
-           (comma-separated list of files with right reads) - single reads
-           (comma-separated list of files with single reads or unpaired reads
-           from paired library) - merged reads (comma-separated list of files
-           with merged reads)) -> structure: parameter "lib_ref" of type
-           "obj_ref" (An X/Y/Z style KBase object reference), parameter
-           "orientation" of String, parameter "lib_type" of String, parameter
-           "long_reads_libraries" of list of type "LongReadsParams" ->
-           structure: parameter "long_reads_ref" of type "obj_ref" (An X/Y/Z
-           style KBase object reference), parameter "long_reads_type" of
-           String, parameter "dna_source" of String, parameter
-           "pipeline_options" of list of String, parameter "kmer_sizes" of
-           list of Long, parameter "create_report" of type "bool" (A boolean.
-           0 = false, anything else = true.)
+           selected. min_contig_length - integer to filter out contigs with
+           length < min_contig_length from the HybridSPAdes output. Default
+           value is 0 implying no filter. @optional dna_source @optional
+           pipeline_options @optional kmer_sizes @optional min_contig_length)
+           -> structure: parameter "workspace_name" of String, parameter
+           "output_contigset_name" of String, parameter "reads_libraries" of
+           list of type "ReadsParams" (parameter groups--define attributes
+           for specifying inputs with YAML data set file (advanced) The
+           following attributes are available: - orientation ("fr", "rf",
+           "ff") - type ("paired-end", "mate-pairs", "hq-mate-pairs",
+           "single", "pacbio", "nanopore", "sanger", "trusted-contigs",
+           "untrusted-contigs") - interlaced reads (comma-separated list of
+           files with interlaced reads) - left reads (comma-separated list of
+           files with left reads) - right reads (comma-separated list of
+           files with right reads) - single reads (comma-separated list of
+           files with single reads or unpaired reads from paired library) -
+           merged reads (comma-separated list of files with merged reads)) ->
+           structure: parameter "lib_ref" of type "obj_ref" (An X/Y/Z style
+           KBase object reference), parameter "orientation" of String,
+           parameter "lib_type" of String, parameter "long_reads_libraries"
+           of list of type "LongReadsParams" -> structure: parameter
+           "long_reads_ref" of type "obj_ref" (An X/Y/Z style KBase object
+           reference), parameter "long_reads_type" of String, parameter
+           "dna_source" of String, parameter "pipeline_options" of list of
+           String, parameter "kmer_sizes" of list of Long, parameter
+           "min_contig_length" of Long, parameter "create_report" of type
+           "bool" (A boolean. 0 = false, anything else = true.)
         :returns: instance of type "SPAdesOutput" (Output parameters for
            SPAdes run. report_name - the name of the KBaseReport.Report
            workspace object. report_ref - the workspace reference of the

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -58,9 +58,9 @@ A coverage cutoff is not specified.
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.1.5"
+    VERSION = "1.2.0"
     GIT_URL = "https://github.com/qzzhang/kb_SPAdes"
-    GIT_COMMIT_HASH = "5fcf49b3bfa09cdc422902634f93ab955888196c"
+    GIT_COMMIT_HASH = "5b7e88d6993728abc26c93cfef780ee7feb16c63"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
@@ -704,7 +704,7 @@ A coverage cutoff is not specified.
         """
         Run HybridSPAdes on paired end libraries with PacBio CLR and Oxford Nanopore reads
         :param params: instance of type "HybridSPAdesParams" (------To run
-           SPAdes 3.13.0 you need at least one library of the following
+           HybridSPAdes 3.13.0 you need at least one library of the following
            types:------ 1) Illumina paired-end/high-quality
            mate-pairs/unpaired reads 2) IonTorrent paired-end/high-quality
            mate-pairs/unpaired reads 3) PacBio CCS reads Version 3.13.0 of
@@ -724,30 +724,33 @@ A coverage cutoff is not specified.
            (optional) K-mer sizes, Default values: 21, 33, 55, 77, 99, 127
            (all values must be odd, less than 128 and listed in ascending
            order) In the absence of these values, K values are automatically
-           selected. @optional dna_source @optional pipeline_options
-           @optional kmer_sizes) -> structure: parameter "workspace_name" of
-           String, parameter "output_contigset_name" of String, parameter
-           "reads_libraries" of list of type "ReadsParams" (parameter
-           groups--define attributes for specifying inputs with YAML data set
-           file (advanced) The following attributes are available: -
-           orientation ("fr", "rf", "ff") - type ("paired-end", "mate-pairs",
-           "hq-mate-pairs", "single", "pacbio", "nanopore", "sanger",
-           "trusted-contigs", "untrusted-contigs") - interlaced reads
-           (comma-separated list of files with interlaced reads) - left reads
-           (comma-separated list of files with left reads) - right reads
-           (comma-separated list of files with right reads) - single reads
-           (comma-separated list of files with single reads or unpaired reads
-           from paired library) - merged reads (comma-separated list of files
-           with merged reads)) -> structure: parameter "lib_ref" of type
-           "obj_ref" (An X/Y/Z style KBase object reference), parameter
-           "orientation" of String, parameter "lib_type" of String, parameter
-           "long_reads_libraries" of list of type "LongReadsParams" ->
-           structure: parameter "long_reads_ref" of type "obj_ref" (An X/Y/Z
-           style KBase object reference), parameter "long_reads_type" of
-           String, parameter "dna_source" of String, parameter
-           "pipeline_options" of list of String, parameter "kmer_sizes" of
-           list of Long, parameter "create_report" of type "bool" (A boolean.
-           0 = false, anything else = true.)
+           selected. min_contig_length - integer to filter out contigs with
+           length < min_contig_length from the HybridSPAdes output. Default
+           value is 0 implying no filter. @optional dna_source @optional
+           pipeline_options @optional kmer_sizes @optional min_contig_length)
+           -> structure: parameter "workspace_name" of String, parameter
+           "output_contigset_name" of String, parameter "reads_libraries" of
+           list of type "ReadsParams" (parameter groups--define attributes
+           for specifying inputs with YAML data set file (advanced) The
+           following attributes are available: - orientation ("fr", "rf",
+           "ff") - type ("paired-end", "mate-pairs", "hq-mate-pairs",
+           "single", "pacbio", "nanopore", "sanger", "trusted-contigs",
+           "untrusted-contigs") - interlaced reads (comma-separated list of
+           files with interlaced reads) - left reads (comma-separated list of
+           files with left reads) - right reads (comma-separated list of
+           files with right reads) - single reads (comma-separated list of
+           files with single reads or unpaired reads from paired library) -
+           merged reads (comma-separated list of files with merged reads)) ->
+           structure: parameter "lib_ref" of type "obj_ref" (An X/Y/Z style
+           KBase object reference), parameter "orientation" of String,
+           parameter "lib_type" of String, parameter "long_reads_libraries"
+           of list of type "LongReadsParams" -> structure: parameter
+           "long_reads_ref" of type "obj_ref" (An X/Y/Z style KBase object
+           reference), parameter "long_reads_type" of String, parameter
+           "dna_source" of String, parameter "pipeline_options" of list of
+           String, parameter "kmer_sizes" of list of Long, parameter
+           "min_contig_length" of Long, parameter "create_report" of type
+           "bool" (A boolean. 0 = false, anything else = true.)
         :returns: instance of type "SPAdesOutput" (Output parameters for
            SPAdes run. report_name - the name of the KBaseReport.Report
            workspace object. report_ref - the workspace reference of the

--- a/lib/kb_SPAdes/utils/spades_assembler.py
+++ b/lib/kb_SPAdes/utils/spades_assembler.py
@@ -34,7 +34,6 @@ class SPAdesAssembler(object):
     PARAM_IN_CS_NAME = 'output_contigset_name'
     SPAdes_PROJECT_DIR = 'spades_project_dir'
     SPAdes_final_scaffolds = 'scaffolds.fasta'  # resulting scaffolds sequences
-    SPAdes_final_contigs = 'contigs.fasta'  # resulting contigs
 
     def __init__(self, config, provenance):
         """
@@ -144,4 +143,4 @@ class SPAdesAssembler(object):
             assemble_ok = -1
 
         # 5. save the assembly to KBase and, if everything has gone well, create a report
-        return self._save_assembly(validated_params, assemble_ok, self.SPAdes_final_contigs)
+        return self._save_assembly(validated_params, assemble_ok)

--- a/lib/kb_SPAdes/utils/spades_utils.py
+++ b/lib/kb_SPAdes/utils/spades_utils.py
@@ -12,7 +12,7 @@ import copy
 import json
 import psutil
 
-from Workspace.WorkspaceClient import Workspace as Workspace
+from Workspace.WorkspaceClient import Workspace
 from KBaseReport.KBaseReportClient import KBaseReport
 from AssemblyUtil.AssemblyUtilClient import AssemblyUtil
 from kb_quast.kb_quastClient import kb_quast

--- a/lib/kb_SPAdes/utils/spades_utils.py
+++ b/lib/kb_SPAdes/utils/spades_utils.py
@@ -314,14 +314,13 @@ class SPAdesUtils:
         if params.get(self.PARAM_IN_WS, None) is None:
             raise ValueError('Parameter {} is mandatory!'.format(self.PARAM_IN_WS))
         if self.INVALID_WS_NAME_RE.search(params[self.PARAM_IN_WS]):
-            raise ValueError('Invalid workspace name: {}.'.format(
-                             params[self.PARAM_IN_WS]))
+            raise ValueError('Invalid workspace name: {}.'.format(params[self.PARAM_IN_WS]))
 
         if params.get(self.PARAM_IN_CS_NAME, None) is None:
             raise ValueError('Parameter {} is mandatory!'.format(self.PARAM_IN_CS_NAME))
         if self.INVALID_WS_OBJ_NAME_RE.search(params[self.PARAM_IN_CS_NAME]):
             raise ValueError('Invalid workspace object name: {}.'.format(
-                             params[self.PARAM_IN_CS_NAME]))
+                params[self.PARAM_IN_CS_NAME]))
 
         if params.get(self.PARAM_IN_READS, None) is None:
             raise ValueError('Parameter {} is mandatory!'.format(self.PARAM_IN_READS))
@@ -476,7 +475,7 @@ class SPAdesUtils:
         """
         rds_params = copy.deepcopy(input_params)
         if rds_params.get(self.PARAM_IN_READS, None) is None:
-            return None
+            return ()  # an empty tuple
 
         wsname = rds_params[self.PARAM_IN_WS]
 

--- a/lib/src/us/kbase/kbspades/HybridSPAdesParams.java
+++ b/lib/src/us/kbase/kbspades/HybridSPAdesParams.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: HybridSPAdesParams</p>
  * <pre>
- * ------To run SPAdes 3.13.0 you need at least one library of the following types:------
+ * ------To run HybridSPAdes 3.13.0 you need at least one library of the following types:------
  *  1) Illumina paired-end/high-quality mate-pairs/unpaired reads
  *  2) IonTorrent paired-end/high-quality mate-pairs/unpaired reads
  *  3) PacBio CCS reads
@@ -33,9 +33,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * kmer_sizes - (optional) K-mer sizes, Default values: 21, 33, 55, 77, 99, 127
  *                  (all values must be odd, less than 128 and listed in ascending order)
  *                  In the absence of these values, K values are automatically selected.
+ * min_contig_length - integer to filter out contigs with length < min_contig_length
+ *                  from the HybridSPAdes output. Default value is 0 implying no filter.    
  * @optional dna_source
  * @optional pipeline_options
  * @optional kmer_sizes
+ * @optional min_contig_length
  * </pre>
  * 
  */
@@ -49,6 +52,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "dna_source",
     "pipeline_options",
     "kmer_sizes",
+    "min_contig_length",
     "create_report"
 })
 public class HybridSPAdesParams {
@@ -67,6 +71,8 @@ public class HybridSPAdesParams {
     private List<String> pipelineOptions;
     @JsonProperty("kmer_sizes")
     private List<Long> kmerSizes;
+    @JsonProperty("min_contig_length")
+    private java.lang.Long minContigLength;
     @JsonProperty("create_report")
     private java.lang.Long createReport;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
@@ -176,6 +182,21 @@ public class HybridSPAdesParams {
         return this;
     }
 
+    @JsonProperty("min_contig_length")
+    public java.lang.Long getMinContigLength() {
+        return minContigLength;
+    }
+
+    @JsonProperty("min_contig_length")
+    public void setMinContigLength(java.lang.Long minContigLength) {
+        this.minContigLength = minContigLength;
+    }
+
+    public HybridSPAdesParams withMinContigLength(java.lang.Long minContigLength) {
+        this.minContigLength = minContigLength;
+        return this;
+    }
+
     @JsonProperty("create_report")
     public java.lang.Long getCreateReport() {
         return createReport;
@@ -203,7 +224,7 @@ public class HybridSPAdesParams {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((("HybridSPAdesParams"+" [workspaceName=")+ workspaceName)+", outputContigsetName=")+ outputContigsetName)+", readsLibraries=")+ readsLibraries)+", longReadsLibraries=")+ longReadsLibraries)+", dnaSource=")+ dnaSource)+", pipelineOptions=")+ pipelineOptions)+", kmerSizes=")+ kmerSizes)+", createReport=")+ createReport)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((("HybridSPAdesParams"+" [workspaceName=")+ workspaceName)+", outputContigsetName=")+ outputContigsetName)+", readsLibraries=")+ readsLibraries)+", longReadsLibraries=")+ longReadsLibraries)+", dnaSource=")+ dnaSource)+", pipelineOptions=")+ pipelineOptions)+", kmerSizes=")+ kmerSizes)+", minContigLength=")+ minContigLength)+", createReport=")+ createReport)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -445,28 +445,28 @@ class hybrid_SPAdesTest(unittest.TestCase):
                                   headers=header, allow_redirects=True).json()
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_fr_pair_kbfile")
+    # @unittest.skip("skipped test_fr_pair_kbfile")
     def test_fr_pair_kbfile(self):
 
         self.run_hybrid_success(
             ['frbasic'], 'frbasic_out')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_fr_pair_kbassy")
+    # @unittest.skip("skipped test_fr_pair_kbassy")
     def test_fr_pair_kbassy(self):
 
         self.run_hybrid_success(
             ['frbasic_kbassy'], 'frbasic_kbassy_out')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_interlaced_kbfile")
+    # @unittest.skip("skipped test_interlaced_kbfile")
     def test_interlaced_kbfile(self):
 
         self.run_hybrid_success(
             ['intbasic'], 'intbasic_out')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_interlaced_kbassy")
+    # @unittest.skip("skipped test_interlaced_kbassy")
     def test_interlaced_kbassy(self):
 
         self.run_hybrid_success(
@@ -474,63 +474,63 @@ class hybrid_SPAdesTest(unittest.TestCase):
             dna_source='')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_multiple")
+    # @unittest.skip("skipped test_multiple")
     def test_multiple(self):
         self.run_hybrid_success(
             ['intbasic_kbassy', 'frbasic'], 'multiple_out',
             dna_source='None')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_plasmid_kbfile")
+    # @unittest.skip("skipped test_plasmid_kbfile")
     def test_plasmid_kbfile(self):
         self.run_hybrid_success(
             ['plasmid_reads'], 'plasmid_out',
             dna_source='plasmid')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_multiple_single")
+    # @unittest.skip("skipped test_multiple_single")
     def test_multiple_single(self):
         self.run_hybrid_success(
             ['single_end', 'single_end2'], 'multiple_single_out',
             dna_source='None', lib_type='single')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_metagenome_kbfile")
+    # @unittest.skip("skipped test_metagenome_kbfile")
     def test_metagenome_kbfile(self):
         self.run_hybrid_success(
             ['meta'], 'metabasic_out',
             dna_source='metagenomic')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_multiple_pacbio_single")
+    # @unittest.skip("skipped test_multiple_pacbio_single")
     def test_multiple_pacbio_single(self):
         self.run_hybrid_success(
             ['single_end'], 'pacbio_single_out', longreadnames=['pacbio'],
             lib_type='single', long_reads_type='pacbio-clr', dna_source='None')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_multiple_pacbio_illumina")
+    # @unittest.skip("skipped test_multiple_pacbio_illumina")
     def test_multiple_pacbio_illumina(self):
         self.run_hybrid_success(
             ['intbasic_kbassy'], 'pacbio_multiple_out', longreadnames=['pacbio'],
             lib_type='single', long_reads_type='pacbio-clr', dna_source='None')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_pacbioccs_alone")
+    # @unittest.skip("skipped test_pacbioccs_alone")
     def test_pacbioccs_alone(self):
         self.run_hybrid_success(
             ['pacbioccs'], 'pacbioccs_alone_out', lib_type='single',
             dna_source='None')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_pacbioccs_single")
+    # @unittest.skip("skipped test_pacbioccs_single")
     def test_pacbioccs_single(self):
         self.run_hybrid_success(
             ['single_end'], 'pacbioccs_single_out', longreadnames=['pacbioccs'],
             lib_type='single', long_reads_type='pacbio-ccs', dna_source='None')
 
     # Uncomment to skip this test
-    @unittest.skip("skipped test_multiple_pacbioccs_illumina")
+    # @unittest.skip("skipped test_multiple_pacbioccs_illumina")
     def test_multiple_pacbioccs_illumina(self):
         self.run_hybrid_success(
             ['intbasic_kbassy'], 'pacbioccs_multiple_out', longreadnames=['pacbioccs'],

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -9,7 +9,6 @@ from ConfigParser import ConfigParser
 import psutil
 
 import requests
-from biokbase.workspace.client import Workspace as workspaceService  # @UnresolvedImport @IgnorePep8
 from biokbase.AbstractHandle.Client import AbstractHandle as HandleService  # @UnresolvedImport @IgnorePep8
 from kb_SPAdes.kb_SPAdesImpl import kb_SPAdes
 from ReadsUtils.ReadsUtilsClient import ReadsUtils
@@ -18,7 +17,7 @@ from pprint import pprint
 import shutil
 import inspect
 
-from Workspace.WorkspaceClient import Workspace as Workspace
+from Workspace.WorkspaceClient import Workspace
 from kb_SPAdes.utils.spades_assembler import SPAdesAssembler
 from kb_SPAdes.utils.spades_utils import SPAdesUtils
 
@@ -383,7 +382,7 @@ class hybrid_SPAdesTest(unittest.TestCase):
                            min_contig_length=0, dna_source=None, kmer_sizes=None,
                            orientation='fr', lib_type='paired-end',
                            long_reads_type='pacbio-clr'):
-        """  
+        """
         run_hybrid_success: The main method to test all possible hybrid input data sets
         """
         test_name = inspect.stack()[1][3]
@@ -444,9 +443,6 @@ class hybrid_SPAdesTest(unittest.TestCase):
         temp_handle_info = self.hs.hids_to_handles([assembly['data']['fasta_handle_ref']])
         assembly_fasta_node = temp_handle_info[0]['id']
         self.nodes_to_delete.append(assembly_fasta_node)
-        header = {"Authorization": "Oauth {0}".format(self.token)}
-        fasta_node = requests.get(self.shockURL + '/node/' + assembly_fasta_node,
-                                  headers=header, allow_redirects=True).json()
 
     # Uncomment to skip this test
     # @unittest.skip("skipped test_fr_pair_kbfile")
@@ -561,22 +557,6 @@ class hybrid_SPAdesTest(unittest.TestCase):
                         'rna',  # --rna
                         'iontorrent'  # --iontorrent
                         ]
-        # a list of read lib objects' names in the workspace
-        lib_nm_list = ['frbasic',
-                       'intbasic',
-                       'intbasic64',
-                       'pacbio',
-                       'pacbioccs',
-                       'iontorrent',
-                       'meta',
-                       'meta2',
-                       'meta_single_end',
-                       'reads_out',
-                       'frbasic_kbassy',
-                       'intbasic_kbassy',
-                       'single_end',
-                       'single_end2',
-                       'plasmid_reads']
 
         pipeline_opts = None
 
@@ -908,13 +888,14 @@ class hybrid_SPAdesTest(unittest.TestCase):
         # test data dirs from SPAdes installation
         spades_test_data_set_dir = '/opt/SPAdes-3.13.0-Linux/share/spades/'
         ecoli_test_data_subdir = 'test_dataset'
-        plasmid_test_data_subdir = 'test_dataset_plasmid'
-        truspades_test_data_subdir = 'test_dataset_truspades'
 
         ecoli1 = os.path.join(spades_test_data_set_dir,
                               ecoli_test_data_subdir, 'ecoli_1K_1.fq.gz')
         ecoli2 = os.path.join(spades_test_data_set_dir,
                               ecoli_test_data_subdir, 'ecoli_1K_2.fq.gz')
+        """
+        plasmid_test_data_subdir = 'test_dataset_plasmid'
+        truspades_test_data_subdir = 'test_dataset_truspades'
         pl1 = os.path.join(spades_test_data_set_dir,
                            plasmid_test_data_subdir, 'pl1.fq.gz')
         pl2 = os.path.join(spades_test_data_set_dir,
@@ -930,7 +911,7 @@ class hybrid_SPAdesTest(unittest.TestCase):
 
         pyyaml2 = os.path.join(spades_test_data_set_dir, 'pyyaml2')
         pyyaml3 = os.path.join(spades_test_data_set_dir, 'pyyaml3')
-
+        """
         dna_src_list = ['single_cell',  # --sc
                         'metagenomic',  # --meta
                         'plasmid',  # --plasmid
@@ -1127,4 +1108,3 @@ class hybrid_SPAdesTest(unittest.TestCase):
         ret = self.spades_assembler.run_hybrid_spades(params5)
         if params5.get('create_report', 0) == 1:
             self.assertReportAssembly(ret, output_name)
-

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -75,7 +75,8 @@ class hybrid_SPAdesTest(unittest.TestCase):
         cls.nodes_to_delete = []
         cls.handles_to_delete = []
         cls.setupTestData()
-        print('\n\n=============== Starting SPAdes tests ==================')
+        cls.setupHybridTestData()
+        print('\n\n=============== Starting HybridSPAdes tests ==================')
 
     @classmethod
     def tearDownClass(cls):
@@ -375,6 +376,31 @@ class hybrid_SPAdesTest(unittest.TestCase):
         print('Data staged.')
 
     @classmethod
+    def setupHybridTestData(cls):
+        print('Shock url ' + cls.shockURL)
+        # print('WS url ' + cls.wsClient.url)
+        print('Handle service url ' + cls.hs.url)
+        print('CPUs detected ' + str(psutil.cpu_count()))
+        print('Available memory ' + str(psutil.virtual_memory().available))
+        print('staging data')
+
+        # get file type from type
+        L8_reads = {'file': 'data/L8_Pig_Type2_ATGTAAGT.inter.fastq',
+                    'name': '',
+                    'type': ''}
+
+        # get nanopore reads
+        L8_np_reads = {'file': 'data/L8_Pig_Type2_BC03.single.fastq',
+                       'name': '',
+                       'type': ''}
+
+        cls.upload_reads('L8paired', {'single_genome': 1}, L8_reads)
+        cls.upload_reads('L8nanopore', {'single_genome': 1}, L8_np_reads,
+                         single_end=True, sequencing_tech="nanopore")
+
+        print('Hybrid data staged.')
+
+    @classmethod
     def make_ref(self, object_info):
         return str(object_info[6]) + '/' + str(object_info[0]) + \
             '/' + str(object_info[4])
@@ -404,7 +430,7 @@ class hybrid_SPAdesTest(unittest.TestCase):
 
         if longreadnames:
             long_libs = [{'long_reads_ref': self.staged[n]['ref'],
-                            'long_reads_type': long_reads_type} for n in longreadnames]
+                          'long_reads_type': long_reads_type} for n in longreadnames]
             params['long_reads_libraries'] = long_libs
 
         if not (dna_source is None):
@@ -542,6 +568,13 @@ class hybrid_SPAdesTest(unittest.TestCase):
         self.run_hybrid_success(
             ['single_end'], 'single_out',
             lib_type='single', dna_source='None')
+
+    # Uncomment to skip this test
+    # @unittest.skip("skipped test_L8_reads")
+    def test_L8_reads(self):
+        self.run_hybrid_success(
+            ['L8paired'], 'nanopore_multiple_out', longreadnames=['L8nanopore'],
+            lib_type='paired-end', long_reads_type='nanopore', dna_source='None')
 
     # ########################End of passed tests######################
 

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -447,28 +447,24 @@ class hybrid_SPAdesTest(unittest.TestCase):
     # Uncomment to skip this test
     # @unittest.skip("skipped test_fr_pair_kbfile")
     def test_fr_pair_kbfile(self):
-
         self.run_hybrid_success(
             ['frbasic'], 'frbasic_out')
 
     # Uncomment to skip this test
     # @unittest.skip("skipped test_fr_pair_kbassy")
     def test_fr_pair_kbassy(self):
-
         self.run_hybrid_success(
             ['frbasic_kbassy'], 'frbasic_kbassy_out')
 
     # Uncomment to skip this test
     # @unittest.skip("skipped test_interlaced_kbfile")
     def test_interlaced_kbfile(self):
-
         self.run_hybrid_success(
             ['intbasic'], 'intbasic_out')
 
     # Uncomment to skip this test
     # @unittest.skip("skipped test_interlaced_kbassy")
     def test_interlaced_kbassy(self):
-
         self.run_hybrid_success(
             ['intbasic_kbassy'], 'intbasic_kbassy_out',
             dna_source='')
@@ -1121,5 +1117,23 @@ class hybrid_SPAdesTest(unittest.TestCase):
                    'create_report': 1
                    }
         ret = self.spades_assembler.run_hybrid_spades(params6)
+        if params6.get('create_report', 0) == 1:
+            self.assertReportAssembly(ret, output_name)
+
+        # test metagenome_kbfile
+        output_name = 'metabasic_out1'
+        dnasrc = dna_src_list[1]
+        libs5 = {'lib_ref': self.staged['meta']['ref'],
+                 'orientation': 'fr',
+                 'lib_type': 'paired-end'}
+        params7 = {'workspace_name': self.getWsName(),
+                   'reads_libraries': [libs5],
+                   'dna_source': dnasrc,
+                   'output_contigset_name': output_name,
+                   'min_contig_length': 0,
+                   'pipeline_options': pipeline_opts,
+                   'create_report': 1
+                   }
+        ret = self.spades_assembler.run_hybrid_spades(params7)
         if params6.get('create_report', 0) == 1:
             self.assertReportAssembly(ret, output_name)

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -380,8 +380,9 @@ class hybrid_SPAdesTest(unittest.TestCase):
             '/' + str(object_info[4])
 
     def run_hybrid_success(self, readnames, output_name, longreadnames=None,
-                           dna_source=None, kmer_sizes=None, orientation='fr',
-                           lib_type='paired-end', long_reads_type='pacbio-clr'):
+                           min_contig_length=0, dna_source=None, kmer_sizes=None,
+                           orientation='fr', lib_type='paired-end',
+                           long_reads_type='pacbio-clr'):
         """  
         run_hybrid_success: The main method to test all possible hybrid input data sets
         """
@@ -399,6 +400,7 @@ class hybrid_SPAdesTest(unittest.TestCase):
         params = {'workspace_name': self.getWsName(),
                   'reads_libraries': libs,
                   'output_contigset_name': output_name,
+                  'min_contig_length': min_contig_length,
                   'create_report': 1
                   }
 
@@ -429,6 +431,8 @@ class hybrid_SPAdesTest(unittest.TestCase):
                          report['data']['objects_created'][0]['description'])
         self.assertIn('Assembled into ', report['data']['text_message'])
         self.assertIn('contigs', report['data']['text_message'])
+        print("**************Report Message*************\n")
+        print(report['data']['text_message'])
 
         assembly_ref = report['data']['objects_created'][0]['ref']
         assembly = self.wsClient.get_objects([{'ref': assembly_ref}])[0]
@@ -1108,3 +1112,19 @@ class hybrid_SPAdesTest(unittest.TestCase):
         ret = self.spades_assembler.run_hybrid_spades(params4)
         if params4.get('create_report', 0) == 1:
             self.assertReportAssembly(ret, output_name)
+
+        # test pairedEnd_cell reads with pacbio clr reads and min_contig_length
+        output_name = rds_name + '_' + rds_name2 + '_mcl_out'
+        params5 = {'workspace_name': self.getWsName(),
+                   'reads_libraries': [libs2],
+                   'long_reads_libraries': [libs4],
+                   'dna_source': dnasrc,
+                   'output_contigset_name': output_name,
+                   'min_contig_length': 500,
+                   'pipeline_options': pipeline_opts,
+                   'create_report': 1
+                   }
+        ret = self.spades_assembler.run_hybrid_spades(params5)
+        if params5.get('create_report', 0) == 1:
+            self.assertReportAssembly(ret, output_name)
+

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -1108,3 +1108,18 @@ class hybrid_SPAdesTest(unittest.TestCase):
         ret = self.spades_assembler.run_hybrid_spades(params5)
         if params5.get('create_report', 0) == 1:
             self.assertReportAssembly(ret, output_name)
+
+        # test pairedEnd_cell reads with pacbio clr reads and 0 min_contig_length
+        output_name = rds_name + '_' + rds_name2 + '_0mcl_out'
+        params6 = {'workspace_name': self.getWsName(),
+                   'reads_libraries': [libs2],
+                   'long_reads_libraries': [libs4],
+                   'dna_source': dnasrc,
+                   'output_contigset_name': output_name,
+                   'min_contig_length': 0,
+                   'pipeline_options': pipeline_opts,
+                   'create_report': 1
+                   }
+        ret = self.spades_assembler.run_hybrid_spades(params6)
+        if params6.get('create_report', 0) == 1:
+            self.assertReportAssembly(ret, output_name)

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -75,7 +75,6 @@ class hybrid_SPAdesTest(unittest.TestCase):
         cls.nodes_to_delete = []
         cls.handles_to_delete = []
         cls.setupTestData()
-        cls.setupHybridTestData()
         print('\n\n=============== Starting HybridSPAdes tests ==================')
 
     @classmethod
@@ -376,31 +375,6 @@ class hybrid_SPAdesTest(unittest.TestCase):
         print('Data staged.')
 
     @classmethod
-    def setupHybridTestData(cls):
-        print('Shock url ' + cls.shockURL)
-        # print('WS url ' + cls.wsClient.url)
-        print('Handle service url ' + cls.hs.url)
-        print('CPUs detected ' + str(psutil.cpu_count()))
-        print('Available memory ' + str(psutil.virtual_memory().available))
-        print('staging data')
-
-        # get file type from type
-        L8_reads = {'file': 'data/L8_Pig_Type2_ATGTAAGT.inter.fastq',
-                    'name': '',
-                    'type': ''}
-
-        # get nanopore reads
-        L8_np_reads = {'file': 'data/L8_Pig_Type2_BC03.single.fastq',
-                       'name': '',
-                       'type': ''}
-
-        cls.upload_reads('L8paired', {'single_genome': 1}, L8_reads)
-        cls.upload_reads('L8nanopore', {'single_genome': 1}, L8_np_reads,
-                         single_end=True, sequencing_tech="nanopore")
-
-        print('Hybrid data staged.')
-
-    @classmethod
     def make_ref(self, object_info):
         return str(object_info[6]) + '/' + str(object_info[0]) + \
             '/' + str(object_info[4])
@@ -568,13 +542,6 @@ class hybrid_SPAdesTest(unittest.TestCase):
         self.run_hybrid_success(
             ['single_end'], 'single_out',
             lib_type='single', dna_source='None')
-
-    # Uncomment to skip this test
-    # @unittest.skip("skipped test_L8_reads")
-    def test_L8_reads(self):
-        self.run_hybrid_success(
-            ['L8paired'], 'nanopore_multiple_out', longreadnames=['L8nanopore'],
-            lib_type='paired-end', long_reads_type='nanopore', dna_source='None')
 
     # ########################End of passed tests######################
 
@@ -1000,7 +967,7 @@ class hybrid_SPAdesTest(unittest.TestCase):
         run_exit_code = spades_utils.run_assemble(single_yaml_file, km_sizes, 'single_cell',
                                                   params1['basic_options'],
                                                   params1['pipeline_options'])
-        print('{} SPAdes assembling returns code= {}'.format(rds_name, run_exit_code))
+        print('{} HybridSPAdes assembling returns code= {}'.format(rds_name, run_exit_code))
         self.assertEqual(run_exit_code, 0)
         self.assertEqual(spades_prjdir, '/kb/module/work/tmp/spades_outputs/single_end')
         self.assertTrue(os.path.isdir(os.path.join(spades_assemble_dir, 'K21')))

--- a/test/kb_SPAdes_server_test.py
+++ b/test/kb_SPAdes_server_test.py
@@ -18,7 +18,6 @@ from kb_SPAdes.kb_SPAdesServer import MethodContext
 from pprint import pprint
 import shutil
 import inspect
-from kb_SPAdes.GenericClient import GenericClient
 
 
 class gaprice_SPAdesTest(unittest.TestCase):
@@ -153,23 +152,23 @@ class gaprice_SPAdesTest(unittest.TestCase):
         ob['wsname'] = cls.getWsName()
         ob['name'] = wsobjname
         if single_end or rev_reads:
-            ob['interleaved']= 0
+            ob['interleaved'] = 0
         else:
-            ob['interleaved']= 1
+            ob['interleaved'] = 1
         print('\n===============staging data for object ' + wsobjname +
               '================')
         print('uploading forward reads file ' + fwd_reads['file'])
         fwd_id, fwd_handle_id, fwd_md5, fwd_size = \
             cls.upload_file_to_shock_and_get_handle(fwd_reads['file'])
 
-        ob['fwd_id']= fwd_id
+        ob['fwd_id'] = fwd_id
         rev_id = None
         rev_handle_id = None
         if rev_reads:
             print('uploading reverse reads file ' + rev_reads['file'])
             rev_id, rev_handle_id, rev_md5, rev_size = \
                 cls.upload_file_to_shock_and_get_handle(rev_reads['file'])
-            ob['rev_id']= rev_id
+            ob['rev_id'] = rev_id
         obj_ref = cls.readUtilsImpl.upload_reads(ob)
         objdata = cls.wsClient.get_object_info_new({
             'objects': [{'ref': obj_ref['obj_ref']}]
@@ -328,18 +327,18 @@ class gaprice_SPAdesTest(unittest.TestCase):
         cls.upload_reads('intbasic', {'single_genome': 1}, int_reads)
         cls.upload_reads('intbasic64', {'single_genome': 1}, int64_reads)
         cls.upload_reads('pacbio', {'single_genome': 1},
-                            pacbio_reads, single_end=True, sequencing_tech="PacBio CLR")
+                         pacbio_reads, single_end=True, sequencing_tech="PacBio CLR")
         cls.upload_reads('pacbioccs', {'single_genome': 1},
-                            pacbio_ccs_reads, single_end=True, sequencing_tech="PacBio CCS")
+                         pacbio_ccs_reads, single_end=True, sequencing_tech="PacBio CCS")
         cls.upload_reads('iontorrent', {'single_genome': 1},
-                            iontorrent_reads, single_end=True, sequencing_tech="IonTorrent")
+                         iontorrent_reads, single_end=True, sequencing_tech="IonTorrent")
         cls.upload_reads('meta', {'single_genome': 0}, fwd_reads,
-                            rev_reads=rev_reads)
+                         rev_reads=rev_reads)
         cls.upload_reads('meta2', {'single_genome': 0}, fwd_reads,
-                            rev_reads=rev_reads)
+                         rev_reads=rev_reads)
         cls.upload_reads('meta_single_end', {'single_genome': 0}, fwd_reads, single_end=True)
         cls.upload_reads('reads_out', {'read_orientation_outward': 1},
-                            int_reads)
+                         int_reads)
         cls.upload_assembly('frbasic_kbassy', {}, fwd_reads,
                             rev_reads=rev_reads, kbase_assy=True)
         cls.upload_assembly('intbasic_kbassy', {}, int_reads, kbase_assy=True)
@@ -440,7 +439,6 @@ class gaprice_SPAdesTest(unittest.TestCase):
         self.run_success(
             ['single_end', 'single_end2'], 'multiple_single_out',
             dna_source='None')
-
 
     def test_iontorrent_alone(self):
         self.run_non_deterministic_success(
@@ -758,10 +756,10 @@ class gaprice_SPAdesTest(unittest.TestCase):
         self.assertEqual('Assembled contigs',
                          report['data']['objects_created'][0]['description'])
         if not (contig_count):
-          self.assertIn('Assembled into ', report['data']['text_message'])
+            self.assertIn('Assembled into ', report['data']['text_message'])
         else:
-          self.assertIn('Assembled into ' + str(contig_count) +
-                      ' contigs', report['data']['text_message'])
+            self.assertIn('Assembled into ' + str(contig_count) +
+                          ' contigs', report['data']['text_message'])
 
         print("PROVENANCE: " + str(report['provenance']))
         self.assertEqual(1, len(report['provenance']))
@@ -802,41 +800,39 @@ class gaprice_SPAdesTest(unittest.TestCase):
                                   headers=header, allow_redirects=True).json()
 
         if not (contig_count is None):
-          self.assertEqual(contig_count, len(assembly['data']['contigs']))
+            self.assertEqual(contig_count, len(assembly['data']['contigs']))
 
         self.assertEqual(output_name, assembly['data']['assembly_id'])
         # self.assertEqual(output_name, assembly['data']['name']) #name key doesnt seem to exist
 
         if not (expected is None):
-          self.assertEqual(expected['fasta_md5'],
-                         fasta_node['data']['file']['checksum']['md5'])
+            self.assertEqual(expected['fasta_md5'],
+                             fasta_node['data']['file']['checksum']['md5'])
 
-          self.assertEqual(expected['md5'], assembly['data']['md5'])
+            self.assertEqual(expected['md5'], assembly['data']['md5'])
 
-          self.assertIn('Assembled into ' + str(contig_count) +
-                      ' contigs', report['data']['text_message'])
+            self.assertIn('Assembled into ' + str(contig_count) +
+                          ' contigs', report['data']['text_message'])
 
-          for exp_contig in expected['contigs']:
-              if exp_contig['id'] in assembly['data']['contigs']:
-                  obj_contig = assembly['data']['contigs'][exp_contig['id']]
-                  self.assertEqual(exp_contig['name'], obj_contig['name'])
-                  self.assertEqual(exp_contig['md5'], obj_contig['md5'])
-                  self.assertEqual(exp_contig['length'], obj_contig['length'])
-              else:
-                  # Hacky way to do this, but need to see all the contig_ids
-                  # They changed because the SPAdes version changed and
-                  # Need to see them to update the tests accordingly.
-                  # If code gets here this test is designed to always fail, but show results.
-                  self.assertEqual(str(assembly['data']['contigs']), "BLAH")
-
+        for exp_contig in expected['contigs']:
+            if exp_contig['id'] in assembly['data']['contigs']:
+                obj_contig = assembly['data']['contigs'][exp_contig['id']]
+                self.assertEqual(exp_contig['name'], obj_contig['name'])
+                self.assertEqual(exp_contig['md5'], obj_contig['md5'])
+                self.assertEqual(exp_contig['length'], obj_contig['length'])
+            else:
+                # Hacky way to do this, but need to see all the contig_ids
+                # They changed because the SPAdes version changed and
+                # Need to see them to update the tests accordingly.
+                # If code gets here this test is designed to always fail, but show results.
+                self.assertEqual(str(assembly['data']['contigs']), "BLAH")
 
     def run_non_deterministic_success(self, readnames, output_name,
-                    dna_source=None):
+                                      dna_source=None):
 
         test_name = inspect.stack()[1][3]
         print('\n**** starting expected success test: ' + test_name + ' *****')
         print('   libs: ' + str(readnames))
-
         print("READNAMES: " + str(readnames))
         print("STAGED: " + str(self.staged))
 
@@ -867,4 +863,3 @@ class gaprice_SPAdesTest(unittest.TestCase):
         assembly = self.wsClient.get_objects([{'ref': assembly_ref}])[0]
         self.assertEqual('KBaseGenomeAnnotations.Assembly', assembly['info'][2].split('-')[0])
         self.assertEqual(output_name, assembly['info'][1])
-        

--- a/ui/narrative/methods/run_hybridSPAdes/display.yaml
+++ b/ui/narrative/methods/run_hybridSPAdes/display.yaml
@@ -67,6 +67,11 @@ parameters :
             Output ContigSet Name<font color=red>*</font>
         short-hint : |
             The name for the resulting ContigSet will be saved in KBase
+    min_contig_length :
+        ui-name : |
+            Minimum Contig Length
+        short-hint : |
+            The shortest contig to accept in the resulting assembly object
     dna_source :
         ui-name : |
             dna_source

--- a/ui/narrative/methods/run_hybridSPAdes/display.yaml
+++ b/ui/narrative/methods/run_hybridSPAdes/display.yaml
@@ -3,7 +3,7 @@
 #
 name: Assemble with HybridSPAdes - v3.13.0
 tooltip: |
-    Assemble reads using the SPAdes assembler.
+    Assemble reads using the HybridSPAdes assembler.
 screenshots: []
 
 icon: spades.png

--- a/ui/narrative/methods/run_hybridSPAdes/spec.json
+++ b/ui/narrative/methods/run_hybridSPAdes/spec.json
@@ -185,14 +185,14 @@
         },
         {
             "id": "min_contig_length",
-            "optional": false,
+            "optional": true,
             "advanced": true,
             "allow_multiple": false,
             "default_values": [ "500" ],
             "field_type": "text",
             "text_options": {
                 "validate_as" : "int",
-		        "min_int" : 200
+		        "min_int" : 0
             }
         },
         {

--- a/ui/narrative/methods/run_hybridSPAdes/spec.json
+++ b/ui/narrative/methods/run_hybridSPAdes/spec.json
@@ -108,10 +108,14 @@
             "optional": true,
             "advanced": true,
             "allow_multiple": false,
-            "default_values": [],
+            "default_values": ["standard"],
             "field_type" : "dropdown",
             "dropdown_options":{
             "options": [
+                {
+                    "value": "standard",
+                    "display": "standard"
+                },
                 {
                   "value": "single_cell",
                   "display": "single cell"

--- a/ui/narrative/methods/run_hybridSPAdes/spec.json
+++ b/ui/narrative/methods/run_hybridSPAdes/spec.json
@@ -105,10 +105,10 @@
         },
         {
             "id": "dna_source",
-            "optional": false,
-            "advanced": false,
+            "optional": true,
+            "advanced": true,
             "allow_multiple": false,
-            "default_values": ["single_cell"],
+            "default_values": [],
             "field_type" : "dropdown",
             "dropdown_options":{
             "options": [

--- a/ui/narrative/methods/run_hybridSPAdes/spec.json
+++ b/ui/narrative/methods/run_hybridSPAdes/spec.json
@@ -184,6 +184,18 @@
             }
         },
         {
+            "id": "min_contig_length",
+            "optional": false,
+            "advanced": true,
+            "allow_multiple": false,
+            "default_values": [ "500" ],
+            "field_type": "text",
+            "text_options": {
+                "validate_as" : "int",
+		        "min_int" : 200
+            }
+        },
+        {
             "id": "kmer_sizes",
             "optional": true,
             "advanced": true,
@@ -240,6 +252,10 @@
                 {
                     "input_parameter": "output_contigset_name",
                     "target_property": "output_contigset_name"
+                },
+                {
+                    "input_parameter": "min_contig_length",
+                    "target_property": "min_contig_length"
                 },
                 {
                     "input_parameter": "kmer_sizes",


### PR DESCRIPTION
After testing the HybridSPAdes with real reads data on appdev beta, we noticed the number of contigs (>0 bp) in the stats was larger than the number of contigs.  Later on investigation told that the number of contigs reported in the stats are count for >=500 bp.  And the stats were calculated on the contigs.fasta while it should be on the scaffolds.fasta.  Therefore, this PR contains all the changes and tests necessary for switching from contigs.fasta to scaffolds.fasta not only for stats but also for saving the assembly.