### PR TITLE
Add resource estimator function

### DIFF
--- a/kb_SPAdes.spec
+++ b/kb_SPAdes.spec
@@ -138,5 +138,29 @@ module kb_SPAdes {
     /* Run SPAdes on paired end libraries for metagenomes */
     funcdef run_metaSPAdes(SPAdesParams params) returns(SPAdesOutput output)
         authentication required;
+
+    /*
+        params - the params used to run metaSPAdes.
+        use_defaults - (optional, def 0) if 1, just return the default requirements
+        use_heuristic - (optional, def 1) if 1, only use a heuristic based on the reads metadata to perform estimates
+    */
+    typedef structure {
+        SPAdesParams params;
+        int use_defaults;
+    } MetaSPAdesEstimatorParams;
+
+    /*
+        cpus - the number of CPUs required for the run
+        memory - the minimal amount of memory in MB required for the run
+        walltime - an estimate for walltime in seconds for the run
+    */
+    typedef structure {
+        int cpus;
+        int memory;
+        int walltime;
+    } MetaSPAdesEstimate;
+    
+    funcdef estimate_metaSPAdes_requirements(MetaSPAdesEstimatorParams params) returns 
+        (MetaSPAdesEstimate results) authentication required;
 };
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.2.3
+    1.3.0
 
 owners:
-    [gaprice, jkbaumohl, rsutormin, dylan, arfath, sychan, psdehal, umaganapathyswork, bsadkhin, qzhang]
+    [gaprice, jkbaumohl, rsutormin, dylan, arfath, sychan, psdehal, umaganapathyswork, bsadkhin, qzhang, wjriehl]

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -57,6 +57,19 @@ function kb_SPAdes(url, auth, auth_cb, timeout, async_job_check_time_ms, service
         return json_call_ajax(_url, "kb_SPAdes.run_metaSPAdes",
             [params], 1, _callback, _errorCallback);
     };
+ 
+     this.estimate_metaSPAdes_requirements = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "kb_SPAdes.estimate_metaSPAdes_requirements",
+            [params], 1, _callback, _errorCallback);
+    };
   
     this.status = function (_callback, _errorCallback) {
         if (_callback && typeof _callback !== 'function')

--- a/lib/kb_SPAdes/authclient.py
+++ b/lib/kb_SPAdes/authclient.py
@@ -24,7 +24,7 @@ class TokenCache(object):
         self._halfmax = maxsize / 2  # int division to round down
 
     def get_user(self, token):
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             usertime = self._cache.get(token)
         if not usertime:
@@ -40,12 +40,15 @@ class TokenCache(object):
             raise ValueError('Must supply token')
         if not user:
             raise ValueError('Must supply user')
-        token = hashlib.sha256(token).hexdigest()
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
-                for i, (t, _) in enumerate(sorted(self._cache.items(),
-                                                  key=lambda (_, v): v[1])):
+                sorted_items = sorted(
+                    list(self._cache.items()),
+                    key=(lambda v: v[1][1])
+                )
+                for i, (t, _) in enumerate(sorted_items):
                     if i <= self._halfmax:
                         del self._cache[t]
                     else:
@@ -57,7 +60,7 @@ class KBaseAuth(object):
     A very basic KBase auth client for the Python server.
     '''
 
-    _LOGIN_URL = 'https://kbase.us/services/authorization/Sessions/Login'
+    _LOGIN_URL = 'https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login'
 
     def __init__(self, auth_url=None):
         '''
@@ -80,11 +83,11 @@ class KBaseAuth(object):
         if not ret.ok:
             try:
                 err = ret.json()
-            except:
+            except Exception as e:
                 ret.raise_for_status()
             raise ValueError('Error connecting to auth service: {} {}\n{}'
                              .format(ret.status_code, ret.reason,
-                                     err['error_msg']))
+                                     err['error']['message']))
 
         user = ret.json()['user_id']
         self._cache.add_valid_token(token, user)

--- a/lib/kb_SPAdes/baseclient.py
+++ b/lib/kb_SPAdes/baseclient.py
@@ -11,6 +11,9 @@ import json as _json
 import requests as _requests
 import random as _random
 import os as _os
+import traceback as _traceback
+from requests.exceptions import ConnectionError
+from urllib3.exceptions import ProtocolError
 
 try:
     from configparser import ConfigParser as _ConfigParser  # py 3
@@ -26,6 +29,7 @@ import time
 _CT = 'content-type'
 _AJ = 'application/json'
 _URL_SCHEME = frozenset(['http', 'https'])
+_CHECK_JOB_RETRYS = 3
 
 
 def _get_token(user_id, password, auth_svc):
@@ -121,7 +125,7 @@ class BaseClient(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login',
+            auth_svc='https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
             lookup_url=False,
             async_job_check_time_ms=100,
             async_job_check_time_scale_percent=150,
@@ -236,20 +240,30 @@ class BaseClient(object):
         mod, _ = service_method.split('.')
         job_id = self._submit_job(service_method, args, service_ver, context)
         async_job_check_time = self.async_job_check_time
-        while True:
+        check_job_failures = 0
+        while check_job_failures < _CHECK_JOB_RETRYS:
             time.sleep(async_job_check_time)
             async_job_check_time = (async_job_check_time *
                                     self.async_job_check_time_scale_percent /
                                     100.0)
             if async_job_check_time > self.async_job_check_max_time:
                 async_job_check_time = self.async_job_check_max_time
-            job_state = self._check_job(mod, job_id)
+
+            try:
+                job_state = self._check_job(mod, job_id)
+            except (ConnectionError, ProtocolError):
+                _traceback.print_exc()
+                check_job_failures += 1
+                continue
+
             if job_state['finished']:
                 if not job_state['result']:
                     return
                 if len(job_state['result']) == 1:
                     return job_state['result'][0]
                 return job_state['result']
+        raise RuntimeError("_check_job failed {} times and exceeded limit".format(
+            check_job_failures))
 
     def call_method(self, service_method, args, service_ver=None,
                     context=None):

--- a/lib/kb_SPAdes/kb_SPAdesClient.pm
+++ b/lib/kb_SPAdes/kb_SPAdesClient.pm
@@ -456,6 +456,122 @@ Run SPAdes on paired end libraries for metagenomes
     }
 }
  
+
+
+=head2 estimate_metaSPAdes_requirements
+
+  $results = $obj->estimate_metaSPAdes_requirements($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a kb_SPAdes.MetaSPAdesEstimatorParams
+$results is a kb_SPAdes.MetaSPAdesEstimate
+MetaSPAdesEstimatorParams is a reference to a hash where the following keys are defined:
+	params has a value which is a kb_SPAdes.SPAdesParams
+	use_defaults has a value which is an int
+SPAdesParams is a reference to a hash where the following keys are defined:
+	workspace_name has a value which is a string
+	output_contigset_name has a value which is a string
+	read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
+	dna_source has a value which is a string
+	min_contig_length has a value which is an int
+	kmer_sizes has a value which is a reference to a list where each element is an int
+	skip_error_correction has a value which is a kb_SPAdes.bool
+paired_end_lib is a string
+bool is an int
+MetaSPAdesEstimate is a reference to a hash where the following keys are defined:
+	cpus has a value which is an int
+	memory has a value which is an int
+	walltime has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a kb_SPAdes.MetaSPAdesEstimatorParams
+$results is a kb_SPAdes.MetaSPAdesEstimate
+MetaSPAdesEstimatorParams is a reference to a hash where the following keys are defined:
+	params has a value which is a kb_SPAdes.SPAdesParams
+	use_defaults has a value which is an int
+SPAdesParams is a reference to a hash where the following keys are defined:
+	workspace_name has a value which is a string
+	output_contigset_name has a value which is a string
+	read_libraries has a value which is a reference to a list where each element is a kb_SPAdes.paired_end_lib
+	dna_source has a value which is a string
+	min_contig_length has a value which is an int
+	kmer_sizes has a value which is a reference to a list where each element is an int
+	skip_error_correction has a value which is a kb_SPAdes.bool
+paired_end_lib is a string
+bool is an int
+MetaSPAdesEstimate is a reference to a hash where the following keys are defined:
+	cpus has a value which is an int
+	memory has a value which is an int
+	walltime has a value which is an int
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub estimate_metaSPAdes_requirements
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function estimate_metaSPAdes_requirements (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to estimate_metaSPAdes_requirements:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'estimate_metaSPAdes_requirements');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "kb_SPAdes.estimate_metaSPAdes_requirements",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'estimate_metaSPAdes_requirements',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method estimate_metaSPAdes_requirements",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'estimate_metaSPAdes_requirements',
+				       );
+    }
+}
+ 
   
 sub status
 {
@@ -499,16 +615,16 @@ sub version {
             Bio::KBase::Exceptions::JSONRPC->throw(
                 error => $result->error_message,
                 code => $result->content->{code},
-                method_name => 'run_metaSPAdes',
+                method_name => 'estimate_metaSPAdes_requirements',
             );
         } else {
             return wantarray ? @{$result->result} : $result->result->[0];
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
-            error => "Error invoking method run_metaSPAdes",
+            error => "Error invoking method estimate_metaSPAdes_requirements",
             status_line => $self->{client}->status_line,
-            method_name => 'run_metaSPAdes',
+            method_name => 'estimate_metaSPAdes_requirements',
         );
     }
 }
@@ -887,6 +1003,86 @@ report_ref has a value which is a string
 a reference to a hash where the following keys are defined:
 report_name has a value which is a string
 report_ref has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 MetaSPAdesEstimatorParams
+
+=over 4
+
+
+
+=item Description
+
+params - the params used to run metaSPAdes.
+use_defaults - (optional, def 0) if 1, just return the default requirements
+use_heuristic - (optional, def 1) if 1, only use a heuristic based on the reads metadata to perform estimates
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+params has a value which is a kb_SPAdes.SPAdesParams
+use_defaults has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+params has a value which is a kb_SPAdes.SPAdesParams
+use_defaults has a value which is an int
+
+
+=end text
+
+=back
+
+
+
+=head2 MetaSPAdesEstimate
+
+=over 4
+
+
+
+=item Description
+
+cpus - the number of CPUs required for the run
+memory - the minimal amount of memory in MB required for the run
+walltime - an estimate for walltime in seconds for the run
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+cpus has a value which is an int
+memory has a value which is an int
+walltime has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+cpus has a value which is an int
+memory has a value which is an int
+walltime has a value which is an int
 
 
 =end text

--- a/lib/kb_SPAdes/kb_SPAdesClient.py
+++ b/lib/kb_SPAdes/kb_SPAdesClient.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 try:
     # baseclient and this client are in a package
     from .baseclient import BaseClient as _BaseClient  # @UnusedImport
-except:
+except ImportError:
     # no they aren't
     from baseclient import BaseClient as _BaseClient  # @Reimport
 
@@ -23,7 +23,7 @@ class kb_SPAdes(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://kbase.us/services/authorization/Sessions/Login'):
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
         if url is None:
             raise ValueError('A url is required')
         self._service_ver = None
@@ -66,9 +66,8 @@ class kb_SPAdes(object):
            report.) -> structure: parameter "report_name" of String,
            parameter "report_ref" of String
         """
-        return self._client.call_method(
-            'kb_SPAdes.run_SPAdes',
-            [params], self._service_ver, context)
+        return self._client.call_method('kb_SPAdes.run_SPAdes',
+                                        [params], self._service_ver, context)
 
     def run_HybridSPAdes(self, params, context=None):
         """
@@ -127,9 +126,8 @@ class kb_SPAdes(object):
            report.) -> structure: parameter "report_name" of String,
            parameter "report_ref" of String
         """
-        return self._client.call_method(
-            'kb_SPAdes.run_HybridSPAdes',
-            [params], self._service_ver, context)
+        return self._client.call_method('kb_SPAdes.run_HybridSPAdes',
+                                        [params], self._service_ver, context)
 
     def run_metaSPAdes(self, params, context=None):
         """
@@ -164,9 +162,48 @@ class kb_SPAdes(object):
            report.) -> structure: parameter "report_name" of String,
            parameter "report_ref" of String
         """
-        return self._client.call_method(
-            'kb_SPAdes.run_metaSPAdes',
-            [params], self._service_ver, context)
+        return self._client.call_method('kb_SPAdes.run_metaSPAdes',
+                                        [params], self._service_ver, context)
+
+    def estimate_metaSPAdes_requirements(self, params, context=None):
+        """
+        :param params: instance of type "MetaSPAdesEstimatorParams" (params -
+           the params used to run metaSPAdes. use_defaults - (optional, def
+           0) if 1, just return the default requirements use_heuristic -
+           (optional, def 1) if 1, only use a heuristic based on the reads
+           metadata to perform estimates) -> structure: parameter "params" of
+           type "SPAdesParams" (Input parameters for running SPAdes.
+           workspace_name - the name of the workspace from which to take
+           input and store output. output_contigset_name - the name of the
+           output contigset read_libraries - a list of Illumina
+           PairedEndLibrary files in FASTQ or BAM format. dna_source -
+           (optional) the source of the DNA used for sequencing
+           'single_cell': DNA amplified from a single cell via MDA anything
+           else: Standard DNA sample from multiple cells. Default value is
+           None. min_contig_length - (optional) integer to filter out contigs
+           with length < min_contig_length from the SPAdes output. Default
+           value is 0 implying no filter. kmer_sizes - (optional) K-mer
+           sizes, Default values: 33, 55, 77, 99, 127 (all values must be
+           odd, less than 128 and listed in ascending order) In the absence
+           of these values, K values are automatically selected.
+           skip_error_correction - (optional) Assembly only (No error
+           correction). By default this is disabled.) -> structure: parameter
+           "workspace_name" of String, parameter "output_contigset_name" of
+           String, parameter "read_libraries" of list of type
+           "paired_end_lib" (The workspace object name of a PairedEndLibrary
+           file, whether of the KBaseAssembly or KBaseFile type.), parameter
+           "dna_source" of String, parameter "min_contig_length" of Long,
+           parameter "kmer_sizes" of list of Long, parameter
+           "skip_error_correction" of type "bool" (A boolean. 0 = false,
+           anything else = true.), parameter "use_defaults" of Long
+        :returns: instance of type "MetaSPAdesEstimate" (cpus - the number of
+           CPUs required for the run memory - the minimal amount of memory in
+           MB required for the run walltime - an estimate for walltime in
+           seconds for the run) -> structure: parameter "cpus" of Long,
+           parameter "memory" of Long, parameter "walltime" of Long
+        """
+        return self._client.call_method('kb_SPAdes.estimate_metaSPAdes_requirements',
+                                        [params], self._service_ver, context)
 
     def status(self, context=None):
         return self._client.call_method('kb_SPAdes.status',

--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -23,6 +23,7 @@ from installed_clients.kb_quastClient import kb_quast
 from installed_clients.kb_ea_utilsClient import kb_ea_utils
 
 from kb_SPAdes.utils.spades_assembler import SPAdesAssembler
+from kb_SPAdes.utils.estimator import estimate_metaSPAdes_reqs
 
 
 class ShockException(Exception):
@@ -54,9 +55,9 @@ A coverage cutoff is not specified.
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.2.0"
-    GIT_URL = "https://github.com/qzzhang/kb_SPAdes"
-    GIT_COMMIT_HASH = "5b7e88d6993728abc26c93cfef780ee7feb16c63"
+    VERSION = "1.2.3"
+    GIT_URL = "https://github.com/briehl/kb_SPAdes"
+    GIT_COMMIT_HASH = "17687df25126cf201693f5686224b4777de36f0b"
 
     #BEGIN_CLASS_HEADER
     # Class variables and functions can be defined in this block
@@ -817,6 +818,57 @@ A coverage cutoff is not specified.
                              'output is not type dict as required.')
         # return the results
         return [output]
+
+    def estimate_metaSPAdes_requirements(self, ctx, params):
+        """
+        :param params: instance of type "MetaSPAdesEstimatorParams" (params -
+           the params used to run metaSPAdes. use_defaults - (optional, def
+           0) if 1, just return the default requirements use_heuristic -
+           (optional, def 1) if 1, only use a heuristic based on the reads
+           metadata to perform estimates) -> structure: parameter "params" of
+           type "SPAdesParams" (Input parameters for running SPAdes.
+           workspace_name - the name of the workspace from which to take
+           input and store output. output_contigset_name - the name of the
+           output contigset read_libraries - a list of Illumina
+           PairedEndLibrary files in FASTQ or BAM format. dna_source -
+           (optional) the source of the DNA used for sequencing
+           'single_cell': DNA amplified from a single cell via MDA anything
+           else: Standard DNA sample from multiple cells. Default value is
+           None. min_contig_length - (optional) integer to filter out contigs
+           with length < min_contig_length from the SPAdes output. Default
+           value is 0 implying no filter. kmer_sizes - (optional) K-mer
+           sizes, Default values: 33, 55, 77, 99, 127 (all values must be
+           odd, less than 128 and listed in ascending order) In the absence
+           of these values, K values are automatically selected.
+           skip_error_correction - (optional) Assembly only (No error
+           correction). By default this is disabled.) -> structure: parameter
+           "workspace_name" of String, parameter "output_contigset_name" of
+           String, parameter "read_libraries" of list of type
+           "paired_end_lib" (The workspace object name of a PairedEndLibrary
+           file, whether of the KBaseAssembly or KBaseFile type.), parameter
+           "dna_source" of String, parameter "min_contig_length" of Long,
+           parameter "kmer_sizes" of list of Long, parameter
+           "skip_error_correction" of type "bool" (A boolean. 0 = false,
+           anything else = true.), parameter "use_defaults" of Long
+        :returns: instance of type "MetaSPAdesEstimate" (cpus - the number of
+           CPUs required for the run memory - the minimal amount of memory in
+           MB required for the run walltime - an estimate for walltime in
+           seconds for the run) -> structure: parameter "cpus" of Long,
+           parameter "memory" of Long, parameter "walltime" of Long
+        """
+        # ctx is the context object
+        # return variables are: results
+        #BEGIN estimate_metaSPAdes_requirements
+        ws = Workspace(self.workspaceURL, token=ctx["token"])
+        results = estimate_metaSPAdes_reqs(params["params"], ws, use_defaults=params.get("use_defaults", 0)==1)
+        #END estimate_metaSPAdes_requirements
+
+        # At some point might do deeper type checking...
+        if not isinstance(results, dict):
+            raise ValueError('Method estimate_metaSPAdes_requirements return value ' +
+                             'results is not type dict as required.')
+        # return the results
+        return [results]
     def status(self, ctx):
         #BEGIN_STATUS
         returnVal = {'state': "OK",

--- a/lib/kb_SPAdes/kb_SPAdesServer.py
+++ b/lib/kb_SPAdes/kb_SPAdesServer.py
@@ -1,22 +1,28 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from wsgiref.simple_server import make_server
-import sys
-import json
-import traceback
 import datetime
-from multiprocessing import Process
+import json
+import os
+import random as _random
+import sys
+import traceback
 from getopt import getopt, GetoptError
-from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError,\
+from multiprocessing import Process
+from os import environ
+from wsgiref.simple_server import make_server
+
+import requests as _requests
+from jsonrpcbase import JSONRPCService, InvalidParamsError, KeywordError, \
     JSONRPCError, InvalidRequestError
 from jsonrpcbase import ServerError as JSONServerError
-from os import environ
-from ConfigParser import ConfigParser
+
 from biokbase import log
-import requests as _requests
-import random as _random
-import os
-from installed_clients.authclient import KBaseAuth as _KBaseAuth
+from kb_SPAdes.authclient import KBaseAuth as _KBaseAuth
+
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 DEPLOY = 'KB_DEPLOYMENT_CONFIG'
 SERVICE = 'KB_SERVICE_NAME'
@@ -109,11 +115,10 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
-            if isinstance(e.message, basestring):
-                newerr.data = e.message
+            if len(e.args) == 1:
+                newerr.data = repr(e.args[0])
             else:
-                # Some exceptions embed other exceptions as the message
-                newerr.data = repr(e.message)
+                newerr.data = repr(e.args)
             raise newerr
         return result
 
@@ -175,7 +180,7 @@ class JSONRPCServiceCustom(JSONRPCService):
 
     def _handle_request(self, ctx, request):
         """Handles given request and returns its response."""
-        if self.method_data[request['method']].has_key('types'):  # noqa @IgnorePep8
+        if 'types' in self.method_data[request['method']]:
             self._validate_params_types(request['method'], request['params'])
 
         result = self._call_method(ctx, request)
@@ -345,6 +350,10 @@ class Application(object):
                              name='kb_SPAdes.run_metaSPAdes',
                              types=[dict])
         self.method_authentication['kb_SPAdes.run_metaSPAdes'] = 'required'  # noqa
+        self.rpc_service.add(impl_kb_SPAdes.estimate_metaSPAdes_requirements,
+                             name='kb_SPAdes.estimate_metaSPAdes_requirements',
+                             types=[dict])
+        self.method_authentication['kb_SPAdes.estimate_metaSPAdes_requirements'] = 'required'  # noqa
         self.rpc_service.add(impl_kb_SPAdes.status,
                              name='kb_SPAdes.status',
                              types=[dict])
@@ -412,7 +421,7 @@ class Application(object):
                                 ctx['user_id'] = user
                                 ctx['authenticated'] = 1
                                 ctx['token'] = token
-                            except Exception, e:
+                            except Exception as e:
                                 if auth_req == 'required':
                                     err = JSONServerError()
                                     err.data = \
@@ -443,11 +452,11 @@ class Application(object):
                     rpc_result = self.process_error(err, ctx, req,
                                                     traceback.format_exc())
 
-        # print 'Request method was %s\n' % environ['REQUEST_METHOD']
-        # print 'Environment dictionary is:\n%s\n' % pprint.pformat(environ)
-        # print 'Request body was: %s' % request_body
-        # print 'Result from the method call is:\n%s\n' % \
-        #    pprint.pformat(rpc_result)
+        # print('Request method was %s\n' % environ['REQUEST_METHOD'])
+        # print('Environment dictionary is:\n%s\n' % pprint.pformat(environ))
+        # print('Request body was: %s' % request_body)
+        # print('Result from the method call is:\n%s\n' % \
+        #    pprint.pformat(rpc_result))
 
         if rpc_result:
             response_body = rpc_result
@@ -461,7 +470,7 @@ class Application(object):
             ('content-type', 'application/json'),
             ('content-length', str(len(response_body)))]
         start_response(status, response_headers)
-        return [response_body]
+        return [response_body.encode('utf8')]
 
     def process_error(self, error, context, request, trace=None):
         if trace:
@@ -513,7 +522,7 @@ try:
 # a wsgi container that has enabled gevent, such as
 # uwsgi with the --gevent option
     if config is not None and config.get('gevent_monkeypatch_all', False):
-        print "Monkeypatching std libraries for async"
+        print("Monkeypatching std libraries for async")
         from gevent import monkey
         monkey.patch_all()
     uwsgi.applications = {'': application}
@@ -537,7 +546,7 @@ def start_server(host='localhost', port=0, newprocess=False):
         raise RuntimeError('server is already running')
     httpd = make_server(host, port, application)
     port = httpd.server_address[1]
-    print "Listening on port %s" % port
+    print("Listening on port %s" % port)
     if newprocess:
         _proc = Process(target=httpd.serve_forever)
         _proc.daemon = True
@@ -616,7 +625,7 @@ if __name__ == "__main__":
         opts, args = getopt(sys.argv[1:], "", ["port=", "host="])
     except GetoptError as err:
         # print help information and exit:
-        print str(err)  # will print something like "option -a not recognized"
+        print(str(err))  # will print something like "option -a not recognized"
         sys.exit(2)
     port = 9999
     host = 'localhost'
@@ -625,12 +634,12 @@ if __name__ == "__main__":
             port = int(a)
         elif o == '--host':
             host = a
-            print "Host set to %s" % host
+            print("Host set to %s" % host)
         else:
             assert False, "unhandled option"
 
     start_server(host=host, port=port)
-#    print "Listening on port %s" % port
+#    print("Listening on port %s" % port)
 #    httpd = make_server( host, port, application)
 #
 #    httpd.serve_forever()

--- a/lib/kb_SPAdes/utils/estimator.py
+++ b/lib/kb_SPAdes/utils/estimator.py
@@ -1,0 +1,66 @@
+def estimate_metaSPAdes_reqs(params, ws, use_defaults=False):
+    """
+    Generates an estimate of how much computational power is needed to run metaSPAdes.
+    params: dict with keys (only relevant ones given):
+        * workspace_name - name of workspace
+        * output_contigset_name
+        * read_libaries - list of names of Paired End library objects
+        * dna_source - string - source of dna?
+        * min_contig_length - int - min contigs to keep in assembly
+        * kmer_sizes - int - length of kmers to use in assembly
+        * skip_error_correction - int - if 1, skips error correction step
+    return: dict with keys:
+        * cpus - int value > 0 - # of cpu cores required
+        * memory - int value > 0 - amount of memory needed in MB
+        * walltime - int value > 0 - seconds of time estimated to run
+    """
+    if not params.get("workspace_name"):
+        raise ValueError("workspace_name is required to estimate metaSPAdes requirements!")
+    if len(params.get("read_libraries", [])) == 0:
+        raise ValueError("At least one read library is required to estimate metaSPAdes requirements!")
+    if use_defaults:
+        return {
+            "cpus": 16,
+            "memory": 4096,
+            "walltime": 300
+        }
+
+    ws_name = params.get("workspace_name")
+    reads_refs = []
+    for lib_name in params["read_libraries"]:
+        reads_refs.append({"ref": lib_name if "/" in lib_name else ws_name + "/" + lib_name})
+    reads_infos = ws.get_object_info3({
+        "objects": reads_refs, 
+        "includeMetadata": 1
+    })
+
+    missing_meta = 0
+    kmer_list = []
+    kmer_len = 31
+    for reads in reads_infos['infos']:
+        meta = reads[10]
+        if 'read_count' in meta and 'read_length_mean' in meta:
+            total_reads = int(meta['read_count'])
+            read_len = float(meta['read_length_mean'])
+            # total number of kmers per read -- upper bound (# unique will be <= the below)
+            kmer_list.append(total_reads * max(0, read_len - kmer_len + 1))
+        else:
+            missing_meta += 1
+    print(reads_infos)
+    print(kmer_list)
+    print(missing_meta)
+    avg_kmer_count = sum(kmer_list)/len(kmer_list)
+    total_kmers = sum(kmer_list) + (avg_kmer_count * missing_meta)
+
+    # now we have an approximation of how many kmers there are. we can use
+    # that to guesstimate how much memory we need
+
+    predicted_mem = (total_kmers * 2.962e-08 + 16.3) * 1.1 * 1024 
+
+    est = {
+        "cpus": 16,
+        "memory": max(int(predicted_mem), 4096),
+        "walltime": max(total_kmers/100000, 300)
+    }
+
+    return est

--- a/lib/src/us/kbase/kbspades/KbSPAdesClient.java
+++ b/lib/src/us/kbase/kbspades/KbSPAdesClient.java
@@ -223,6 +223,23 @@ public class KbSPAdesClient {
         return res.get(0);
     }
 
+    /**
+     * <p>Original spec-file function name: estimate_metaSPAdes_requirements</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.kbspades.MetaSPAdesEstimatorParams MetaSPAdesEstimatorParams}
+     * @return   parameter "results" of type {@link us.kbase.kbspades.MetaSPAdesEstimate MetaSPAdesEstimate}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public MetaSPAdesEstimate estimateMetaSPAdesRequirements(MetaSPAdesEstimatorParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<MetaSPAdesEstimate>> retType = new TypeReference<List<MetaSPAdesEstimate>>() {};
+        List<MetaSPAdesEstimate> res = caller.jsonrpcCall("kb_SPAdes.estimate_metaSPAdes_requirements", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
     public Map<String, Object> status(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         TypeReference<List<Map<String, Object>>> retType = new TypeReference<List<Map<String, Object>>>() {};

--- a/lib/src/us/kbase/kbspades/MetaSPAdesEstimate.java
+++ b/lib/src/us/kbase/kbspades/MetaSPAdesEstimate.java
@@ -1,0 +1,100 @@
+
+package us.kbase.kbspades;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: MetaSPAdesEstimate</p>
+ * <pre>
+ * cpus - the number of CPUs required for the run
+ * memory - the minimal amount of memory in MB required for the run
+ * walltime - an estimate for walltime in seconds for the run
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "cpus",
+    "memory",
+    "walltime"
+})
+public class MetaSPAdesEstimate {
+
+    @JsonProperty("cpus")
+    private Long cpus;
+    @JsonProperty("memory")
+    private Long memory;
+    @JsonProperty("walltime")
+    private Long walltime;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("cpus")
+    public Long getCpus() {
+        return cpus;
+    }
+
+    @JsonProperty("cpus")
+    public void setCpus(Long cpus) {
+        this.cpus = cpus;
+    }
+
+    public MetaSPAdesEstimate withCpus(Long cpus) {
+        this.cpus = cpus;
+        return this;
+    }
+
+    @JsonProperty("memory")
+    public Long getMemory() {
+        return memory;
+    }
+
+    @JsonProperty("memory")
+    public void setMemory(Long memory) {
+        this.memory = memory;
+    }
+
+    public MetaSPAdesEstimate withMemory(Long memory) {
+        this.memory = memory;
+        return this;
+    }
+
+    @JsonProperty("walltime")
+    public Long getWalltime() {
+        return walltime;
+    }
+
+    @JsonProperty("walltime")
+    public void setWalltime(Long walltime) {
+        this.walltime = walltime;
+    }
+
+    public MetaSPAdesEstimate withWalltime(Long walltime) {
+        this.walltime = walltime;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("MetaSPAdesEstimate"+" [cpus=")+ cpus)+", memory=")+ memory)+", walltime=")+ walltime)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbspades/MetaSPAdesEstimatorParams.java
+++ b/lib/src/us/kbase/kbspades/MetaSPAdesEstimatorParams.java
@@ -1,0 +1,145 @@
+
+package us.kbase.kbspades;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: MetaSPAdesEstimatorParams</p>
+ * <pre>
+ * params - the params used to run metaSPAdes.
+ * use_defaults - (optional, def 0) if 1, just return the default requirements
+ * use_heuristic - (optional, def 1) if 1, only use a heuristic based on the reads metadata to perform estimates
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "params",
+    "use_defaults"
+})
+public class MetaSPAdesEstimatorParams {
+
+    /**
+     * <p>Original spec-file type: SPAdesParams</p>
+     * <pre>
+     * Input parameters for running SPAdes.
+     * workspace_name - the name of the workspace from which to take input
+     *                  and store output.
+     * output_contigset_name - the name of the output contigset
+     * read_libraries - a list of Illumina PairedEndLibrary files in FASTQ or BAM format.
+     * dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
+     *                  amplified from a single cell via MDA anything else: Standard
+     *                  DNA sample from multiple cells. Default value is None.
+     * min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
+     *                  from the SPAdes output. Default value is 0 implying no filter.
+     * kmer_sizes - (optional) K-mer sizes, Default values: 33, 55, 77, 99, 127
+     *                  (all values must be odd, less than 128 and listed in ascending order)
+     *                  In the absence of these values, K values are automatically selected.
+     * skip_error_correction - (optional) Assembly only (No error correction).
+     *                  By default this is disabled.
+     * </pre>
+     * 
+     */
+    @JsonProperty("params")
+    private SPAdesParams params;
+    @JsonProperty("use_defaults")
+    private Long useDefaults;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * <p>Original spec-file type: SPAdesParams</p>
+     * <pre>
+     * Input parameters for running SPAdes.
+     * workspace_name - the name of the workspace from which to take input
+     *                  and store output.
+     * output_contigset_name - the name of the output contigset
+     * read_libraries - a list of Illumina PairedEndLibrary files in FASTQ or BAM format.
+     * dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
+     *                  amplified from a single cell via MDA anything else: Standard
+     *                  DNA sample from multiple cells. Default value is None.
+     * min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
+     *                  from the SPAdes output. Default value is 0 implying no filter.
+     * kmer_sizes - (optional) K-mer sizes, Default values: 33, 55, 77, 99, 127
+     *                  (all values must be odd, less than 128 and listed in ascending order)
+     *                  In the absence of these values, K values are automatically selected.
+     * skip_error_correction - (optional) Assembly only (No error correction).
+     *                  By default this is disabled.
+     * </pre>
+     * 
+     */
+    @JsonProperty("params")
+    public SPAdesParams getParams() {
+        return params;
+    }
+
+    /**
+     * <p>Original spec-file type: SPAdesParams</p>
+     * <pre>
+     * Input parameters for running SPAdes.
+     * workspace_name - the name of the workspace from which to take input
+     *                  and store output.
+     * output_contigset_name - the name of the output contigset
+     * read_libraries - a list of Illumina PairedEndLibrary files in FASTQ or BAM format.
+     * dna_source - (optional) the source of the DNA used for sequencing 'single_cell': DNA
+     *                  amplified from a single cell via MDA anything else: Standard
+     *                  DNA sample from multiple cells. Default value is None.
+     * min_contig_length - (optional) integer to filter out contigs with length < min_contig_length
+     *                  from the SPAdes output. Default value is 0 implying no filter.
+     * kmer_sizes - (optional) K-mer sizes, Default values: 33, 55, 77, 99, 127
+     *                  (all values must be odd, less than 128 and listed in ascending order)
+     *                  In the absence of these values, K values are automatically selected.
+     * skip_error_correction - (optional) Assembly only (No error correction).
+     *                  By default this is disabled.
+     * </pre>
+     * 
+     */
+    @JsonProperty("params")
+    public void setParams(SPAdesParams params) {
+        this.params = params;
+    }
+
+    public MetaSPAdesEstimatorParams withParams(SPAdesParams params) {
+        this.params = params;
+        return this;
+    }
+
+    @JsonProperty("use_defaults")
+    public Long getUseDefaults() {
+        return useDefaults;
+    }
+
+    @JsonProperty("use_defaults")
+    public void setUseDefaults(Long useDefaults) {
+        this.useDefaults = useDefaults;
+    }
+
+    public MetaSPAdesEstimatorParams withUseDefaults(Long useDefaults) {
+        this.useDefaults = useDefaults;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("MetaSPAdesEstimatorParams"+" [params=")+ params)+", useDefaults=")+ useDefaults)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/test/kb_SPAdes_Hybrid_test.py
+++ b/test/kb_SPAdes_Hybrid_test.py
@@ -20,7 +20,6 @@ from installed_clients.WorkspaceClient import Workspace
 from kb_SPAdes.utils.spades_assembler import SPAdesAssembler
 from kb_SPAdes.utils.spades_utils import SPAdesUtils
 
-
 class hybrid_SPAdesTest(unittest.TestCase):
 
     @classmethod

--- a/test/kb_SPAdes_server_test.py
+++ b/test/kb_SPAdes_server_test.py
@@ -19,7 +19,6 @@ from pprint import pprint
 import shutil
 import inspect
 
-
 class gaprice_SPAdesTest(unittest.TestCase):
 
     @classmethod

--- a/test/spades_estimator_test.py
+++ b/test/spades_estimator_test.py
@@ -1,0 +1,180 @@
+import unittest
+import os
+import time
+
+from os import environ
+from ConfigParser import ConfigParser
+import psutil
+
+import requests
+from biokbase.workspace.client import Workspace as workspaceService  # @UnresolvedImport @IgnorePep8
+from biokbase.workspace.client import ServerError as WorkspaceError  # @UnresolvedImport @IgnorePep8
+from biokbase.AbstractHandle.Client import AbstractHandle as HandleService  # @UnresolvedImport @IgnorePep8
+from kb_SPAdes.kb_SPAdesImpl import kb_SPAdes
+from installed_clients.baseclient import ServerError
+from installed_clients.ReadsUtilsClient import ReadsUtils
+from kb_SPAdes.kb_SPAdesServer import MethodContext
+from pprint import pprint
+import shutil
+import inspect
+from kb_SPAdes.utils.estimator import estimate_metaSPAdes_reqs
+import mock
+
+
+
+class SimpleMockWs():
+    """
+    Mocks out a couple simple workspace commands.
+    Intended only for local use against the spades estimator.
+    Workspace / object ids are effectively random on each return.
+    expects ObjectSpecification inputs to be "ref" with "ws_name/obj_name" formatting.
+    """
+
+    ws_mapping = dict()
+    # Structured like this:
+    # {
+    #     ws_name : {
+    #         id: int,
+    #         objects: {
+    #             name1: int,
+    #             name2: int, ...etc
+    #         }
+    #     }
+    # }
+
+    def __init__(self, *args, **kwargs):
+        self.ws_mapping = dict()
+        self.skip_even_meta = kwargs.get("skip_even_meta", False)
+    
+    def get_object_info3(self, params):
+        ret_val = {
+            "infos": [],
+            "paths": []
+        }        
+        for o in params["objects"]:
+            self._setup_ids(o)
+            ret_val["infos"].append(self._object_info(o, with_meta=params.get("includeMetadata", 0)==1))
+            ret_val["paths"].append(self._object_to_path(o))
+        return ret_val
+
+    def _setup_ids(self, obj):
+        if "ref" in obj:
+            split_ref = obj["ref"].split("/")
+            ws_name, obj_name = split_ref[:2]
+        if "workspace" in obj:
+            ws_name = obj["workspace"]
+        if "name" in obj:
+            obj_name = obj["name"]
+        if ws_name not in self.ws_mapping:
+            ws_id = len(self.ws_mapping) + 1
+            self.ws_mapping[ws_name] = {
+                "id": ws_id,
+                "objects": {}
+            }
+        if obj_name not in self.ws_mapping[ws_name]:
+            self.ws_mapping[ws_name]["objects"][obj_name] = len(self.ws_mapping[ws_name]["objects"]) + 1
+
+    def _object_to_path(self, obj):
+        ws_name, obj_name = obj["ref"].split("/")[:2]
+        return "/".join([
+            str(self.ws_mapping[ws_name]['id']),
+            str(self.ws_mapping[ws_name]['objects'][obj_name]),
+            "1"
+        ])
+    
+    def _object_info(self, obj, with_meta=False):
+        ws_name, obj_name = obj["ref"].split("/")[:2]
+        ws_id = self.ws_mapping[ws_name]["id"]
+        obj_id = self.ws_mapping[ws_name]["objects"][obj_name]
+        meta = {}
+        if with_meta and not (obj_id % 2 == 0 and self.skip_even_meta):
+            meta = {
+                "read_count": "10000",
+                "read_length_mean": "100.0",
+                "total_bases": "1000000"
+            }
+        return [obj_id, obj_name, "KBaseFile.PairedEndLibrary-2.2", "some_timestamp", 1, "some_user", ws_id, ws_name, "some_hash", 123, meta]
+
+
+class SpadesEstimatorTestCase(unittest.TestCase):
+    simple_params = {
+        "workspace_name": "SomeWs",
+        "read_libraries": ["SomeWs/Lib1", "SomeWs/Lib2", "SomeWs/Lib3", "Lib4"]
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.token = environ.get('KB_AUTH_TOKEN')
+        cls.callbackURL = environ.get('SDK_CALLBACK_URL')
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': cls.token,
+                        'provenance': [
+                            {'service': 'kb_SPAdes',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
+        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('kb_SPAdes'):
+            cls.cfg[nameval[0]] = nameval[1]
+        cls.cfg["SDK_CALLBACK_URL"] = cls.callbackURL
+        cls.cfg["KB_AUTH_TOKEN"] = cls.token
+        cls.serviceImpl = kb_SPAdes(cls.cfg)
+
+    def test_estimator(self):
+        ws = SimpleMockWs()
+        est = estimate_metaSPAdes_reqs(self.simple_params, ws)
+        self.assertEqual(est["cpus"], 16)
+        self.assertEqual(est["walltime"], 300)
+        self.assertEqual(est["memory"], 18453)
+    
+    def test_estimator_defaults(self):
+        ws = SimpleMockWs()
+        estimates = estimate_metaSPAdes_reqs(self.simple_params, ws, use_defaults=True)
+        self.assertEqual(estimates, {"cpus": 16, "memory": 4096, "walltime": 300})
+
+    def test_estimator_bad_inputs(self):
+        ws = SimpleMockWs()
+        with self.assertRaises(ValueError) as e:
+            estimate_metaSPAdes_reqs({ "read_libraries": ['some_lib'] }, ws)
+        self.assertIn("workspace_name is required to estimate metaSPAdes requirements!", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            estimate_metaSPAdes_reqs({ "workspace_name": "foo" }, ws)
+        self.assertIn("At least one read library is required to estimate metaSPAdes requirements!", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            estimate_metaSPAdes_reqs({ "workspace_name": "foo", "read_libraries": [] }, ws)
+        self.assertIn("At least one read library is required to estimate metaSPAdes requirements!", str(e.exception))
+
+    def test_estimator_missing_meta(self):
+        ws = SimpleMockWs(skip_even_meta=True)
+        est = estimate_metaSPAdes_reqs(self.simple_params, ws)
+        self.assertEqual(est["cpus"], 16)
+        self.assertEqual(est["walltime"], 300)
+        self.assertEqual(est["memory"], 18453)
+    
+    @mock.patch('kb_SPAdes.kb_SPAdesImpl.Workspace', SimpleMockWs)
+    def test_estimator_impl_simple(self):
+        est = self.serviceImpl.estimate_metaSPAdes_requirements(self.ctx, {
+            "params": self.simple_params,
+            "use_defaults": 0
+        })[0]
+        self.assertEqual(est["cpus"], 16)
+        self.assertEqual(est["walltime"], 300)
+        self.assertEqual(est["memory"], 18453)
+
+    @mock.patch('kb_SPAdes.kb_SPAdesImpl.Workspace', SimpleMockWs)
+    def test_estimator_impl_defaults(self):
+        est = self.serviceImpl.estimate_metaSPAdes_requirements(self.ctx, {
+            "params": self.simple_params,
+            "use_defaults": 1
+        })[0]
+        self.assertEqual(est["cpus"], 16)
+        self.assertEqual(est["walltime"], 300)
+        self.assertEqual(est["memory"], 4096)

--- a/ui/narrative/methods/run_metaSPAdes/spec.json
+++ b/ui/narrative/methods/run_metaSPAdes/spec.json
@@ -74,6 +74,8 @@
             "url": "",
             "name": "kb_SPAdes",
             "method": "run_metaSPAdes",
+            "resource_estimator_module": "kb_SPAdes",
+            "resource_estimator_method": "estimate_metaSPAdes_requirements",
             "input_mapping": [
                 {
                     "narrative_system_variable": "workspace",


### PR DESCRIPTION
This is a fairly cheesy estimator, but the memory reqs are based on some truth. The function it uses is:
```
predicted_mem = (kmers * 2.962e-08 + 1.630e+01) * 1.1
```
where `predicted_mem` is in GB and `kmers` is the total number of unique 31-mers. This first passes uses the total number of 31-mers in all passed reads files (so, an upper-bound, really).

The estimated CPUs is just set to 16 (kinda arbitrary, we can adjust - default threads in the JGI MG pipeline is 32) and estimated walltime is a fraction of the unique 31-mers, or 300s, whatever's greater.