### PR TITLE
MAX_MEMORY_GB_SPADES to 225

### DIFF
--- a/lib/kb_SPAdes/kb_SPAdesImpl.py
+++ b/lib/kb_SPAdes/kb_SPAdesImpl.py
@@ -83,7 +83,7 @@ A coverage cutoff is not specified.
     MAX_THREADS_META = 128  # Increase threads for metagenomic assemblies
     MEMORY_OFFSET_GB = 1  # 1GB
     MIN_MEMORY_GB = 5
-    MAX_MEMORY_GB_SPADES = 500
+    MAX_MEMORY_GB_SPADES = 225
     MAX_MEMORY_GB_META_SPADES = 1000
     GB = 1000000000
 


### PR DESCRIPTION
Bigmem does not have 500 gb of memory. These jobs keep trying to use up all of the memory and crash the system.